### PR TITLE
Add code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,4 @@ networks: {
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for style and how to contribute.
+All communication and contributions to the Celo project are subject to the [Celo Code of Conduct](https://celo.org/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -262,4 +262,4 @@ networks: {
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for style and how to contribute.
-All communication and contributions to the Celo project are subject to the [Celo Code of Conduct](https://celo.org/code-of-conduct).
+All communication and contributions to this project are subject to the [Celo Code of Conduct](code-of-conduct.md).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,4 @@
+<!-- Inherited from https://github.com/celo-org/website/blob/master/src/content/code-of-conduct.md -->
 ---
 title: Celo Community Code of Conduct
 description: The Celo Code of Conduct is one of the ways we bring our value of connectedness into practice.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,8 +1,9 @@
-<!-- Inherited from https://github.com/celo-org/website/blob/master/src/content/code-of-conduct.md -->
 ---
 title: Celo Community Code of Conduct
 description: The Celo Code of Conduct is one of the ways we bring our value of connectedness into practice.
 ---
+
+<!-- Inherited from https://github.com/celo-org/website/blob/master/src/content/code-of-conduct.md -->
 
 ### 1. Purpose
 The Celo Code of Conduct is one of the ways we bring our value of connectedness into practice. A primary goal of the Celo community is to be welcoming and inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,80 @@
+---
+title: Celo Community Code of Conduct
+description: The Celo Code of Conduct is one of the ways we bring our value of connectedness into practice.
+---
+
+### 1. Purpose
+The Celo Code of Conduct is one of the ways we bring our value of connectedness into practice. A primary goal of the Celo community is to be welcoming and inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible.
+
+As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We invite all those who participate in the Celo community to help us create safe and positive experiences for everyone.
+
+### 2. Open Source Citizenship
+A supplemental goal of this Code of Conduct is to increase open source citizenship by encouraging participants to recognize and strengthen the relationships between our own actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+### 3. Scope
+We expect all community participants (users; validators; contributors–paid or otherwise; sponsors; cLabs employees; and others) to abide by this Code of Conduct in all community undertakings and venues–online and in-person–as well as in all one-on-one communications pertaining to community business.
+
+This Code of Conduct and its related procedures also apply to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
+
+### 4. Expected Behavior
+The following behaviors are expected and requested of all community members:
+Exercise consideration and respect in your speech and actions. Use welcoming and inclusive language.
+Attempt collaboration before conflict.
+Refrain from demeaning, discriminatory, critical, or harassing behavior and speech.
+Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+### 5. Unacceptable Behavior
+The following behaviors are considered harassment and are unacceptable within the Celo community. Please note that this is not a comprehensive list, and in general, anything which could reasonably be considered inappropriate in a professional setting is unacceptable.
+
+* Violence, threats of violence, or violent language directed against another person.
+* Hurtful or harmful language related to:
+
+  * Background
+  * Family status
+  * Gender
+  * Gender identity or expression
+  * Marital status
+  * Sex
+  * Sexual orientation
+  * Native language
+  * Age
+  * Ability
+  * Race and/or ethnicity
+  * Caste
+  * National origin
+  * Socioeconomic status
+  * Religion
+  * Geographic location
+  * Other attributes
+
+* Posting or displaying sexually explicit or violent material.
+* Deceptive, fraudulent, or otherwise misleading communications or actions, including attempts to manipulate the price of any digital assets.
+* Posting or threatening to post other people’s personally identifying information ("doxing").
+* Personal insults, including but not limited to those related to gender, sexual orientation, race, religion, or disability.
+* Inappropriate photography or recording.
+* Inappropriate physical contact. You should have someone’s consent before touching them.
+* Sexual attention, including sexualized comments or jokes or emojis; inappropriate touching, groping, and unwelcome sexual advances.
+* Unhelpfully criticizing, flaming, or trolling members or community initiatives.
+* Deliberate intimidation, stalking, or following (online or in-person).
+* Sustained disruption of community events, including talks and presentations.
+* Advocating for, or encouraging, any of the above behavior.
+
+### 6. Consequences of Unacceptable Behavior
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. Violation of this Code of Conduct can result in you being asked to leave an event or online space, either temporarily or for the duration of the event (without refund in the case of a paid event), or being banned from participation in spaces, or future events and activities in perpetuity.
+
+Celo community members are held accountable, in addition to these guidelines, to their respective employment Anti-Harassment/Discrimination Policies. Where applicable, any such staff in violation of this Code of Conduct may be subject to further consequences, such as disciplinary action, up to and including termination of employment. For Celo community contractors or vendors, violation of this Code of Conduct could affect the continuation or renewal of a contract.
+### 7. License and attribution
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/3.0/). Portions of text derived from the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md ), the [Django Code of Conduct](https://www.djangoproject.com/conduct/), the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Community_anti-harassment), the [Mozilla Foundation](https://www.mozilla.org/en-US/about/governance/policies/participation/#note-1), and the [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
+
+### 8. Modifications
+
+The Celo Foundation may amend this Code of Conduct from time to time and may also vary the procedures it sets out where appropriate in a particular case. Your agreement to comply with the guidelines will be deemed agreement to any changes to it.
+
+*Last updated on the 9th of July 2021*


### PR DESCRIPTION
### Description
Add code of conduct
This is needed for opensource gitbook licence.

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/8665738/183043580-491d8ee0-bb44-49d6-903c-bab5ce42bfc6.png">
