### PR TITLE
Updated validator health check

### DIFF
--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -252,14 +252,12 @@ contract Manager is UUPSOwnableUpgradeable, UsingRegistryUpgradeable {
         if (slashMultiplier < 10**24) {
             return false;
         }
-        // check for majority of members are elected.
-        uint256 counter = 0;
+        // check that at least one member is elected.
         for (uint256 i = 0; i < members.length; i++) {
-            if (!isGroupMemberElected(members[i])) {
-                counter++;
-                if (counter >= members.length / 2) {
-                    return false;
-                }
+            if (isGroupMemberElected(members[i])) {
+                break;
+            } else if (i == (members.length - 1)) {
+                return false;
             }
         }
         return true;

--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -255,12 +255,10 @@ contract Manager is UUPSOwnableUpgradeable, UsingRegistryUpgradeable {
         // check that at least one member is elected.
         for (uint256 i = 0; i < members.length; i++) {
             if (isGroupMemberElected(members[i])) {
-                break;
-            } else if (i == (members.length - 1)) {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     /**

--- a/test-ts/manager.test.ts
+++ b/test-ts/manager.test.ts
@@ -203,6 +203,31 @@ describe("Manager", () => {
       });
     });
 
+    describe("when group has 3 validators, but only 1 is elected.", () => {
+      let gloup: SignerWithAddress;
+      beforeEach(async () => {
+        [gloup] = await randomSigner(parseUnits("31000"));
+        await registerValidatorGroup(gloup);
+
+        for (let i = 0; i < 3; i++) {
+          const [validator, validatorWallet] = await randomSigner(parseUnits("11000"));
+
+          if (i === 2) {
+            await registerValidatorAndAddToGroupMembers(gloup, validator, validatorWallet);
+            await electGroup(gloup.address, someone);
+          } else {
+            await registerValidatorAndOnlyAffiliateToGroup(gloup, validator, validatorWallet);
+          }
+        }
+      });
+
+      it("emits a GroupActivated event", async () => {
+        await expect(manager.activateGroup(gloup.address))
+          .to.emit(manager, "GroupActivated")
+          .withArgs(gloup.address);
+      });
+    });
+
     describe("when group has low slash multiplier", () => {
       let slashedGroup: SignerWithAddress;
       beforeEach(async () => {
@@ -360,7 +385,7 @@ describe("Manager", () => {
         expect(activeGroups).to.deep.eq([groupAddresses[0], groupAddresses[2]]);
       });
 
-      it("does not add the group to the deprecatedd array", async () => {
+      it("does not add the group to the deprecated array", async () => {
         await manager.deprecateGroup(deprecatedGroup.address);
         const deprecatedGroups = await manager.getDeprecatedGroups();
         expect(deprecatedGroups).to.deep.eq([]);
@@ -455,6 +480,32 @@ describe("Manager", () => {
         await expect(await manager.deprecateUnhealthyGroup(deprecatedGroup.address))
           .to.emit(manager, "GroupDeprecated")
           .withArgs(deprecatedGroup.address);
+      });
+    });
+
+    describe("when group has 3 validators, but only 1 is elected.", () => {
+      let gloups: SignerWithAddress;
+      beforeEach(async () => {
+        [gloups] = await randomSigner(parseUnits("21000"));
+        await registerValidatorGroup(gloups);
+
+        for (let i = 0; i < 3; i++) {
+          const [validator, validatorWallet] = await randomSigner(parseUnits("11000"));
+
+          if (i === 2) {
+            await registerValidatorAndAddToGroupMembers(gloups, validator, validatorWallet);
+            await electGroup(gloups.address, someone);
+          } else {
+            await registerValidatorAndOnlyAffiliateToGroup(gloups, validator, validatorWallet);
+          }
+        }
+        await manager.activateGroup(gloups.address);
+      });
+
+      it("should revert with Healthy group message", async () => {
+        await expect(manager.deprecateUnhealthyGroup(gloups.address)).revertedWith(
+          `HealthyGroup("${gloups.address}")`
+        );
       });
     });
 


### PR DESCRIPTION
### Description

Update the validator health check to require that at least one member is elected, as oposed to half of the members being elected. 

Given that there is no penalty to only having one member elected, this change will ultimatly save some gas


### Tested

Unit tested
