### PR TITLE
Allow any address to execute a confirmed proposal.

### DIFF
--- a/contracts/common/MultiSig.sol
+++ b/contracts/common/MultiSig.sol
@@ -684,7 +684,6 @@ contract MultiSig is Initializable, UUPSUpgradeable {
      */
     function executeProposal(uint256 proposalId)
         public
-        ownerExists(msg.sender)
         scheduled(proposalId)
         notExecuted(proposalId)
         timeLockReached(proposalId)

--- a/test-ts/multisig.test.ts
+++ b/test-ts/multisig.test.ts
@@ -405,25 +405,6 @@ describe("MultiSig", () => {
       expect(await multiSig.delay()).to.be.equal(9 * DAY);
       expect(await multiSig.isOwner(nonOwner.address)).to.be.true;
     });
-
-    it("should be successfully execute a proposal by account", async () => {
-      const secondPayload = multiSig.interface.encodeFunctionData("changeDelay", [9 * DAY]);
-      const values = [0, 0];
-      const destinations = [multiSig.address, multiSig.address];
-
-      await executeMultisigProposal(
-        multiSig,
-        destinations,
-        values,
-        [txData, secondPayload],
-        delay,
-        owner1,
-        owner2
-      );
-
-      expect(await multiSig.delay()).to.be.equal(9 * DAY);
-      expect(await multiSig.isOwner(nonOwner.address)).to.be.true;
-    });
   });
 
   describe("#revokeConfirmation()", () => {


### PR DESCRIPTION
**Description**
Currently only a multisig owner can execute a proposal. Technically this restriction may not be needed, since a proposal can only be executed IFF all confirmations have been successful and timelock delay has elapsed.

This will be useful on mainnet for an engineer ( since we are not part of the multisig owners ) to go in an execute a proposal after it has been confirmed and all the time locked delay has reached.


### Tested

Unit tests.

### Related issues

- Fixes #95 
