### PR TITLE
Allow Celo Governance to execute proposals as the stCELO MultiSig

### DIFF
--- a/contracts/common/MultiSig.sol
+++ b/contracts/common/MultiSig.sol
@@ -872,6 +872,12 @@ contract MultiSig is Initializable, UUPSUpgradeable, UsingRegistryNoStorage {
         return (1, 1, 1, 0);
     }
 
+    /**
+     * @notice Executes a proposal made by Celo Governance.
+     * @dev Only callable by the Celo Governance contract, as defined in the
+     * Celo Registry. Thus, this function may be called via a Governance
+     * referendum or hotfix.
+     */
     function governanceProposeAndExecute(
         address[] calldata destinations,
         uint256[] calldata values,

--- a/contracts/common/MultiSig.sol
+++ b/contracts/common/MultiSig.sol
@@ -114,13 +114,6 @@ contract MultiSig is Initializable, UUPSUpgradeable, UsingRegistryNoStorage {
     event ProposalAdded(uint256 indexed proposalId);
 
     /**
-     * @notice Emitted when a confirmed proposal is successfully executed.
-     * @param proposalId The ID of the proposal that was executed.
-     * @param returnData The response that was recieved from the external call.
-     */
-    event ProposalExecuted(uint256 indexed proposalId, bytes returnData);
-
-    /**
      * @notice Emitted when one of the transactions that make up a proposal is successfully
      * executed.
      * @param index The index of the transaction within the proposal.

--- a/contracts/common/MultiSig.sol
+++ b/contracts/common/MultiSig.sol
@@ -713,6 +713,33 @@ contract MultiSig is Initializable, UUPSUpgradeable, UsingRegistryNoStorage {
     }
 
     /**
+     * @notice Executes a proposal made by Celo Governance.
+     * @dev Only callable by the Celo Governance contract, as defined in the
+     * Celo Registry. Thus, this function may be called via a Governance
+     * referendum or hotfix.
+     */
+    function governanceProposeAndExecute(
+        address[] calldata destinations,
+        uint256[] calldata values,
+        bytes[] calldata payloads
+    ) external {
+        address governanceAddress = address(getGovernance());
+
+        if (msg.sender != governanceAddress) {
+            revert SenderNotGovernance(msg.sender);
+        }
+
+        for (uint256 i = 0; i < destinations.length; i++) {
+            bytes memory returnData = ExternalCall.execute(
+                destinations[i],
+                values[i],
+                payloads[i]
+            );
+            emit GovernanceTransactionExecuted(i, returnData);
+        }
+    }
+
+    /**
      * @notice Returns the timestamp at which a proposal becomes executable.
      * @param proposalId The ID of the proposal.
      * @return The timestamp at which the proposal becomes executable.
@@ -870,32 +897,5 @@ contract MultiSig is Initializable, UUPSUpgradeable, UsingRegistryNoStorage {
         )
     {
         return (1, 1, 1, 0);
-    }
-
-    /**
-     * @notice Executes a proposal made by Celo Governance.
-     * @dev Only callable by the Celo Governance contract, as defined in the
-     * Celo Registry. Thus, this function may be called via a Governance
-     * referendum or hotfix.
-     */
-    function governanceProposeAndExecute(
-        address[] calldata destinations,
-        uint256[] calldata values,
-        bytes[] calldata payloads
-    ) external {
-        address governanceAddress = address(getGovernance());
-
-        if (msg.sender != governanceAddress) {
-            revert SenderNotGovernance(msg.sender);
-        }
-
-        for (uint256 i = 0; i < destinations.length; i++) {
-            bytes memory returnData = ExternalCall.execute(
-                destinations[i],
-                values[i],
-                payloads[i]
-            );
-            emit GovernanceTransactionExecuted(i, returnData);
-        }
     }
 }

--- a/contracts/common/MultiSig.sol
+++ b/contracts/common/MultiSig.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 import "../libraries/ExternalCall.sol";
+import "./UsingRegistryNoStorage.sol";
 
 /**
  * @title Multisignature wallet - Allows multiple parties to agree on proposals before
@@ -29,7 +30,7 @@ import "../libraries/ExternalCall.sol";
  * Forked from
  * github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/common/MultiSig.sol
  */
-contract MultiSig is Initializable, UUPSUpgradeable {
+contract MultiSig is Initializable, UUPSUpgradeable, UsingRegistryNoStorage {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /**
@@ -127,6 +128,14 @@ contract MultiSig is Initializable, UUPSUpgradeable {
      * @param returnData The response that was recieved from the external call.
      */
     event TransactionExecuted(uint256 index, uint256 indexed proposalId, bytes returnData);
+
+    /**
+     * @notice Emitted when one of the transactions that make up a Governance proposal is successfully
+     * executed.
+     * @param index The index of the transaction within the proposal.
+     * @param returnData The response that was recieved from the external call.
+     */
+    event GovernanceTransactionExecuted(uint256 index, bytes returnData);
 
     /**
      * @notice Emitted when CELO is sent to this contract.
@@ -267,6 +276,8 @@ contract MultiSig is Initializable, UUPSUpgradeable {
      * when submitting a proposal.
      */
     error ParamLengthsMismatch();
+
+    error SenderNotGovernance(address sender);
 
     /**
      * @notice Checks that only the multisig contract can execute a function.
@@ -859,5 +870,26 @@ contract MultiSig is Initializable, UUPSUpgradeable {
         )
     {
         return (1, 1, 1, 0);
+    }
+
+    function governanceProposeAndExecute(
+        address[] calldata destinations,
+        uint256[] calldata values,
+        bytes[] calldata payloads
+    ) external {
+        address governanceAddress = address(getGovernance());
+
+        if (msg.sender != governanceAddress) {
+            revert SenderNotGovernance(msg.sender);
+        }
+
+        for (uint256 i = 0; i < destinations.length; i++) {
+            bytes memory returnData = ExternalCall.execute(
+                destinations[i],
+                values[i],
+                payloads[i]
+            );
+            emit GovernanceTransactionExecuted(i, returnData);
+        }
     }
 }

--- a/contracts/common/MultiSig.sol
+++ b/contracts/common/MultiSig.sol
@@ -730,11 +730,7 @@ contract MultiSig is Initializable, UUPSUpgradeable, UsingRegistryNoStorage {
         }
 
         for (uint256 i = 0; i < destinations.length; i++) {
-            bytes memory returnData = ExternalCall.execute(
-                destinations[i],
-                values[i],
-                payloads[i]
-            );
+            bytes memory returnData = ExternalCall.execute(destinations[i], values[i], payloads[i]);
             emit GovernanceTransactionExecuted(i, returnData);
         }
     }

--- a/contracts/common/UsingRegistryNoStorage.sol
+++ b/contracts/common/UsingRegistryNoStorage.sol
@@ -10,7 +10,10 @@ import "../interfaces/IGovernance.sol";
 import "../interfaces/IValidators.sol";
 
 /**
- * @title A helper for getting Celo core contracts from the Registry.
+ * @title A helper for getting Celo core contracts from the Registry. This
+ * version stores the canonical Celo Registry address in a constant and doesn't
+ * use any storage slots, thus can be inserted into the inheritance tree of an
+ * already existing contract.
  */
 abstract contract UsingRegistryNoStorage {
     /// @notice The canonical address of the Registry.

--- a/contracts/common/UsingRegistryNoStorage.sol
+++ b/contracts/common/UsingRegistryNoStorage.sol
@@ -1,0 +1,90 @@
+//SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.11;
+
+import "../interfaces/IAccounts.sol";
+import "../interfaces/IElection.sol";
+import "../interfaces/IGoldToken.sol";
+import "../interfaces/ILockedGold.sol";
+import "../interfaces/IRegistry.sol";
+import "../interfaces/IGovernance.sol";
+import "../interfaces/IValidators.sol";
+
+/**
+ * @title A helper for getting Celo core contracts from the Registry.
+ */
+abstract contract UsingRegistryNoStorage {
+    /// @notice The canonical address of the Registry.
+    address internal constant CANONICAL_REGISTRY = 0x000000000000000000000000000000000000ce10;
+
+    /// @notice The registry ID for the Accounts contract.
+    bytes32 private constant ACCOUNTS_REGISTRY_ID = keccak256(abi.encodePacked("Accounts"));
+
+    /// @notice The registry ID for the Election contract.
+    bytes32 private constant ELECTION_REGISTRY_ID = keccak256(abi.encodePacked("Election"));
+
+    /// @notice The registry ID for the GoldToken contract.
+    bytes32 private constant GOLD_TOKEN_REGISTRY_ID = keccak256(abi.encodePacked("GoldToken"));
+
+    /// @notice The registry ID for the LockedGold contract.
+    bytes32 private constant LOCKED_GOLD_REGISTRY_ID = keccak256(abi.encodePacked("LockedGold"));
+
+    /// @notice The registry ID for the Governance contract.
+    bytes32 private constant GOVERNANCE_REGISTRY_ID = keccak256(abi.encodePacked("Governance"));
+
+    /// @notice The registry ID for the Validator contract.
+    bytes32 private constant VALIDATORS_REGISTRY_ID = keccak256(abi.encodePacked("Validators"));
+
+    /**
+     * @notice Gets the Accounts contract from the Registry.
+     * @return The Accounts contract from the Registry.
+     */
+    function getAccounts() internal view returns (IAccounts) {
+        IRegistry registry = IRegistry(CANONICAL_REGISTRY);
+        return IAccounts(registry.getAddressForOrDie(ACCOUNTS_REGISTRY_ID));
+    }
+
+    /**
+     * @notice Gets the Election contract from the Registry.
+     * @return The Election contract from the Registry.
+     */
+    function getElection() internal view returns (IElection) {
+        IRegistry registry = IRegistry(CANONICAL_REGISTRY);
+        return IElection(registry.getAddressForOrDie(ELECTION_REGISTRY_ID));
+    }
+
+    /**
+     * @notice Gets the GoldToken contract from the Registry.
+     * @return The GoldToken contract from the Registry.
+     */
+    function getGoldToken() internal view returns (IGoldToken) {
+        IRegistry registry = IRegistry(CANONICAL_REGISTRY);
+        return IGoldToken(registry.getAddressForOrDie(GOLD_TOKEN_REGISTRY_ID));
+    }
+
+    /**
+     * @notice Gets the LockedGold contract from the Registry.
+     * @return The LockedGold contract from the Registry.
+     */
+    function getLockedGold() internal view returns (ILockedGold) {
+        IRegistry registry = IRegistry(CANONICAL_REGISTRY);
+        return ILockedGold(registry.getAddressForOrDie(LOCKED_GOLD_REGISTRY_ID));
+    }
+
+    /**
+     * @notice Gets the Governance contract from the Registry.
+     * @return The Governance contract from the Registry.
+     */
+    function getGovernance() internal view returns (IGovernance) {
+        IRegistry registry = IRegistry(CANONICAL_REGISTRY);
+        return IGovernance(registry.getAddressForOrDie(GOVERNANCE_REGISTRY_ID));
+    }
+
+    /**
+     * @notice Gets the validators contract from the Registry.
+     * @return The validators contract from the Registry.
+     */
+    function getValidators() internal view returns (IValidators) {
+        IRegistry registry = IRegistry(CANONICAL_REGISTRY);
+        return IValidators(registry.getAddressForOrDie(VALIDATORS_REGISTRY_ID));
+    }
+}

--- a/contracts/test/ProposalTester.sol
+++ b/contracts/test/ProposalTester.sol
@@ -12,7 +12,7 @@ contract ProposalTester {
 
     error CallDoesNotExist(uint256 i);
 
-    function testCall(uint256 x) payable public {
+    function testCall(uint256 x) public payable {
         Call memory newCall = Call(msg.sender, msg.value, x);
         calls.push(newCall);
     }
@@ -21,7 +21,15 @@ contract ProposalTester {
         return calls.length;
     }
 
-    function getCall(uint256 i) external view returns (address, uint256, uint256) {
+    function getCall(uint256 i)
+        external
+        view
+        returns (
+            address,
+            uint256,
+            uint256
+        )
+    {
         if (i >= calls.length) {
             revert CallDoesNotExist(i);
         }

--- a/contracts/test/ProposalTester.sol
+++ b/contracts/test/ProposalTester.sol
@@ -1,0 +1,32 @@
+//SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.11;
+
+contract ProposalTester {
+    struct Call {
+        address caller;
+        uint256 value;
+        uint256 argument;
+    }
+
+    Call[] calls;
+
+    error CallDoesNotExist(uint256 i);
+
+    function testCall(uint256 x) payable public {
+        Call memory newCall = Call(msg.sender, msg.value, x);
+        calls.push(newCall);
+    }
+
+    function numberCalls() external view returns (uint256) {
+        return calls.length;
+    }
+
+    function getCall(uint256 i) external view returns (address, uint256, uint256) {
+        if (i >= calls.length) {
+            revert CallDoesNotExist(i);
+        }
+
+        Call memory call = calls[i];
+        return (call.caller, call.value, call.argument);
+    }
+}

--- a/test-ts/multisig.test.ts
+++ b/test-ts/multisig.test.ts
@@ -4,7 +4,9 @@ import { BigNumber, BigNumberish, Signer } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import hre, { ethers } from "hardhat";
 import { MultiSig } from "../typechain-types/MultiSig";
-import { ADDRESS_ZERO, DAY, randomSigner, timeTravel } from "./utils";
+import { ProposalTester__factory } from "../typechain-types/factories/ProposalTester__factory";
+import { ProposalTester } from "../typechain-types/ProposalTester";
+import { ADDRESS_ZERO, DAY, getImpersonatedSigner, randomSigner, timeTravel } from "./utils";
 
 /**
  * Invokes the multisig's submitProposal, waits for the confirmation event
@@ -815,4 +817,103 @@ describe("MultiSig", () => {
       expect(await multiSig.isProposalTimelockReached(proposalId)).to.be.false;
     });
   });
+
+  describe("#governanceProposeAndExecute()", () => {
+    describe("when sender is Governance", () => {
+      let governance: SignerWithAddress
+      let proposalTester: ProposalTester
+
+      beforeEach(async () => {
+        const governanceAddress = (await hre.kit.contracts.getGovernance()).address
+        governance = await getImpersonatedSigner(governanceAddress, BigNumber.from("100000000000000000000"))
+        const proposalTesterFactory: ProposalTester__factory = await hre.ethers.getContractFactory('ProposalTester')
+        proposalTester = await proposalTesterFactory.deploy()
+      })
+
+      it("succeeds for the Governance address", async () => {
+        await multiSig.connect(governance).governanceProposeAndExecute([], [], [])
+      })
+
+      it("allows Governance to call a contract", async () => {
+        const txData = proposalTester.interface.encodeFunctionData("testCall", [42]);
+        await multiSig.connect(governance).governanceProposeAndExecute([proposalTester.address], [0], [txData])
+        const result = await proposalTester.getCall(0)
+        expect(result[0]).to.equal(multiSig.address)
+        expect(result[1]).to.equal(0)
+        expect(result[2]).to.equal(42)
+      })
+
+      it("allows Governance to send value", async () => {
+        const balanceBefore = await hre.ethers.provider.getBalance(multiSig.address)
+        await owner1.sendTransaction({
+          to: multiSig.address,
+          value: 300
+        })
+        const balanceAfter = await hre.ethers.provider.getBalance(multiSig.address)
+
+        const txData = proposalTester.interface.encodeFunctionData("testCall", [42]);
+
+        await multiSig.connect(governance).governanceProposeAndExecute([proposalTester.address], [100], [txData])
+        const multiSigBalance = await hre.ethers.provider.getBalance(multiSig.address)
+        const testerBalance = await hre.ethers.provider.getBalance(proposalTester.address)
+        const result = await proposalTester.getCall(0)
+        expect(result[0]).to.equal(multiSig.address)
+        expect(result[1]).to.equal(100)
+        expect(multiSigBalance).to.equal(200)
+        expect(testerBalance).to.equal(100)
+        expect(result[2]).to.equal(42)
+      })
+
+      it("allows Governance to call multiple functions atomically", async () => {
+        const txData1 = proposalTester.interface.encodeFunctionData("testCall", [42]);
+        const txData2 = proposalTester.interface.encodeFunctionData("testCall", [1337]);
+        await multiSig.connect(governance).governanceProposeAndExecute(
+          [proposalTester.address, proposalTester.address],
+          [0, 0],
+          [txData1, txData2]
+        )
+        const result1 = await proposalTester.getCall(0)
+        const result2 = await proposalTester.getCall(1)
+        expect(result1[0]).to.equal(multiSig.address)
+        expect(result1[1]).to.equal(0)
+        expect(result1[2]).to.equal(42)
+        expect(result2[0]).to.equal(multiSig.address)
+        expect(result2[1]).to.equal(0)
+        expect(result2[2]).to.equal(1337)
+      })
+
+      it("allows Governance to execute a MultiSig function", async () => {
+        const txData = multiSig.interface.encodeFunctionData("addOwner", [nonOwner.address]);
+        await multiSig.connect(governance).governanceProposeAndExecute(
+          [multiSig.address],
+          [0],
+          [txData]
+        )
+
+        const isOwner = await multiSig.isOwner(nonOwner.address)
+        expect(isOwner).to.be.true
+      })
+
+      it("emits a GovernanceTransactionExecuted event", async () => {
+        const txData = proposalTester.interface.encodeFunctionData("testCall", [42]);
+        await expect(
+          multiSig.connect(governance).governanceProposeAndExecute([proposalTester.address], [0], [txData])
+        )
+          .to.emit(multiSig, "GovernanceTransactionExecuted")
+          .withArgs(0, '0x');
+      });
+    })
+
+    it("should revert for an owner address", async () => {
+      await expect(multiSig.connect(owner1).governanceProposeAndExecute([], [], [])).revertedWith(
+        "SenderNotGovernance"
+      );
+    })
+
+    it("should revert for a random address", async () => {
+      await expect(multiSig.connect(nonOwner).governanceProposeAndExecute([], [], [])).revertedWith(
+        "SenderNotGovernance"
+      );
+    })
+  })
 });

--- a/test-ts/multisig.test.ts
+++ b/test-ts/multisig.test.ts
@@ -3,8 +3,8 @@ import { expect } from "chai";
 import { BigNumber, BigNumberish, Signer } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import hre, { ethers } from "hardhat";
-import { MultiSig } from "../typechain-types/MultiSig";
 import { ProposalTester__factory } from "../typechain-types/factories/ProposalTester__factory";
+import { MultiSig } from "../typechain-types/MultiSig";
 import { ProposalTester } from "../typechain-types/ProposalTester";
 import { ADDRESS_ZERO, DAY, getImpersonatedSigner, randomSigner, timeTravel } from "./utils";
 
@@ -820,100 +820,111 @@ describe("MultiSig", () => {
 
   describe("#governanceProposeAndExecute()", () => {
     describe("when sender is Governance", () => {
-      let governance: SignerWithAddress
-      let proposalTester: ProposalTester
+      let governance: SignerWithAddress;
+      let proposalTester: ProposalTester;
 
       beforeEach(async () => {
-        const governanceAddress = (await hre.kit.contracts.getGovernance()).address
-        governance = await getImpersonatedSigner(governanceAddress, BigNumber.from("100000000000000000000"))
-        const proposalTesterFactory: ProposalTester__factory = await hre.ethers.getContractFactory('ProposalTester')
-        proposalTester = await proposalTesterFactory.deploy()
-      })
+        const governanceAddress = (await hre.kit.contracts.getGovernance()).address;
+        governance = await getImpersonatedSigner(
+          governanceAddress,
+          BigNumber.from("100000000000000000000")
+        );
+        const proposalTesterFactory: ProposalTester__factory = await hre.ethers.getContractFactory(
+          "ProposalTester"
+        );
+        proposalTester = await proposalTesterFactory.deploy();
+      });
 
       it("succeeds for the Governance address", async () => {
-        await multiSig.connect(governance).governanceProposeAndExecute([], [], [])
-      })
+        await multiSig.connect(governance).governanceProposeAndExecute([], [], []);
+      });
 
       it("allows Governance to call a contract", async () => {
         const txData = proposalTester.interface.encodeFunctionData("testCall", [42]);
-        await multiSig.connect(governance).governanceProposeAndExecute([proposalTester.address], [0], [txData])
-        const result = await proposalTester.getCall(0)
-        expect(result[0]).to.equal(multiSig.address)
-        expect(result[1]).to.equal(0)
-        expect(result[2]).to.equal(42)
-      })
+        await multiSig
+          .connect(governance)
+          .governanceProposeAndExecute([proposalTester.address], [0], [txData]);
+        const result = await proposalTester.getCall(0);
+        expect(result[0]).to.equal(multiSig.address);
+        expect(result[1]).to.equal(0);
+        expect(result[2]).to.equal(42);
+      });
 
       it("allows Governance to send value", async () => {
-        const balanceBefore = await hre.ethers.provider.getBalance(multiSig.address)
+        const balanceBefore = await hre.ethers.provider.getBalance(multiSig.address);
         await owner1.sendTransaction({
           to: multiSig.address,
-          value: 300
-        })
-        const balanceAfter = await hre.ethers.provider.getBalance(multiSig.address)
+          value: 300,
+        });
+        const balanceAfter = await hre.ethers.provider.getBalance(multiSig.address);
 
         const txData = proposalTester.interface.encodeFunctionData("testCall", [42]);
 
-        await multiSig.connect(governance).governanceProposeAndExecute([proposalTester.address], [100], [txData])
-        const multiSigBalance = await hre.ethers.provider.getBalance(multiSig.address)
-        const testerBalance = await hre.ethers.provider.getBalance(proposalTester.address)
-        const result = await proposalTester.getCall(0)
-        expect(result[0]).to.equal(multiSig.address)
-        expect(result[1]).to.equal(100)
-        expect(multiSigBalance).to.equal(200)
-        expect(testerBalance).to.equal(100)
-        expect(result[2]).to.equal(42)
-      })
+        await multiSig
+          .connect(governance)
+          .governanceProposeAndExecute([proposalTester.address], [100], [txData]);
+        const multiSigBalance = await hre.ethers.provider.getBalance(multiSig.address);
+        const testerBalance = await hre.ethers.provider.getBalance(proposalTester.address);
+        const result = await proposalTester.getCall(0);
+        expect(result[0]).to.equal(multiSig.address);
+        expect(result[1]).to.equal(100);
+        expect(multiSigBalance).to.equal(200);
+        expect(testerBalance).to.equal(100);
+        expect(result[2]).to.equal(42);
+      });
 
       it("allows Governance to call multiple functions atomically", async () => {
         const txData1 = proposalTester.interface.encodeFunctionData("testCall", [42]);
         const txData2 = proposalTester.interface.encodeFunctionData("testCall", [1337]);
-        await multiSig.connect(governance).governanceProposeAndExecute(
-          [proposalTester.address, proposalTester.address],
-          [0, 0],
-          [txData1, txData2]
-        )
-        const result1 = await proposalTester.getCall(0)
-        const result2 = await proposalTester.getCall(1)
-        expect(result1[0]).to.equal(multiSig.address)
-        expect(result1[1]).to.equal(0)
-        expect(result1[2]).to.equal(42)
-        expect(result2[0]).to.equal(multiSig.address)
-        expect(result2[1]).to.equal(0)
-        expect(result2[2]).to.equal(1337)
-      })
+        await multiSig
+          .connect(governance)
+          .governanceProposeAndExecute(
+            [proposalTester.address, proposalTester.address],
+            [0, 0],
+            [txData1, txData2]
+          );
+        const result1 = await proposalTester.getCall(0);
+        const result2 = await proposalTester.getCall(1);
+        expect(result1[0]).to.equal(multiSig.address);
+        expect(result1[1]).to.equal(0);
+        expect(result1[2]).to.equal(42);
+        expect(result2[0]).to.equal(multiSig.address);
+        expect(result2[1]).to.equal(0);
+        expect(result2[2]).to.equal(1337);
+      });
 
       it("allows Governance to execute a MultiSig function", async () => {
         const txData = multiSig.interface.encodeFunctionData("addOwner", [nonOwner.address]);
-        await multiSig.connect(governance).governanceProposeAndExecute(
-          [multiSig.address],
-          [0],
-          [txData]
-        )
+        await multiSig
+          .connect(governance)
+          .governanceProposeAndExecute([multiSig.address], [0], [txData]);
 
-        const isOwner = await multiSig.isOwner(nonOwner.address)
-        expect(isOwner).to.be.true
-      })
+        const isOwner = await multiSig.isOwner(nonOwner.address);
+        expect(isOwner).to.be.true;
+      });
 
       it("emits a GovernanceTransactionExecuted event", async () => {
         const txData = proposalTester.interface.encodeFunctionData("testCall", [42]);
         await expect(
-          multiSig.connect(governance).governanceProposeAndExecute([proposalTester.address], [0], [txData])
+          multiSig
+            .connect(governance)
+            .governanceProposeAndExecute([proposalTester.address], [0], [txData])
         )
           .to.emit(multiSig, "GovernanceTransactionExecuted")
-          .withArgs(0, '0x');
+          .withArgs(0, "0x");
       });
-    })
+    });
 
     it("should revert for an owner address", async () => {
       await expect(multiSig.connect(owner1).governanceProposeAndExecute([], [], [])).revertedWith(
         "SenderNotGovernance"
       );
-    })
+    });
 
     it("should revert for a random address", async () => {
       await expect(multiSig.connect(nonOwner).governanceProposeAndExecute([], [], [])).revertedWith(
         "SenderNotGovernance"
       );
-    })
-  })
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,11 @@
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-2.3.0.tgz#a6369473200d5cc7e856a2a95a3f4d2fddfbfc6b"
   integrity sha512-Jo81eVGCPcKpUw9G4/uFE2x2TeYpS6BhEpmzmrkL86AU+EC93ES9UUlCcCpFSVRfoiHldIGp2QzyU+kAYap//Q==
 
+"@celo/base@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@celo/base/-/base-4.1.0.tgz#9cd45f1c7d0ac61b4e2e98c046066f9eb9e143e9"
+  integrity sha512-Q9wKLa4JJw06FXpToZm5PYfFYjx+tvwIQlvFofx+GleX+uq+BT/gdxgTQ/c08OrxZUyc53TUdqSCs+88VlhmlA==
+
 "@celo/celo-devchain@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@celo/celo-devchain/-/celo-devchain-5.0.0.tgz#8cbbda702097a6008071a13738d6c3ae0a650f13"
@@ -504,6 +509,19 @@
   dependencies:
     "@celo/base" "2.3.0"
     "@celo/utils" "2.3.0"
+    "@types/debug" "^4.1.5"
+    "@types/utf8" "^2.1.6"
+    bignumber.js "^9.0.0"
+    debug "^4.1.1"
+    utf8 "3.0.0"
+
+"@celo/connect@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@celo/connect/-/connect-4.1.0.tgz#bcdd2a37e7c6e034371a097810f7e64444de397e"
+  integrity sha512-1PaPy/b9ZLtXGCNN7lqlt0Nqsw/Ql20iCcOZbrAhoN9HkxtHI/yMK7p9aMGDR0Qy4jEi123p8kt5qgJhH2IkKg==
+  dependencies:
+    "@celo/base" "4.1.0"
+    "@celo/utils" "4.1.0"
     "@types/debug" "^4.1.5"
     "@types/utf8" "^2.1.6"
     bignumber.js "^9.0.0"
@@ -551,7 +569,7 @@
     web3-core "^1.7.5"
     web3-provider-engine "^16.0.4"
 
-"@celo/contractkit@^1.2.4", "@celo/contractkit@^1.5.2":
+"@celo/contractkit@^1.2.4":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-1.5.2.tgz#be15d570f3044a190dabb6bbe53d5081c78ea605"
   integrity sha512-b0r5TlfYDEscxze1Ai2jyJayiVElA9jvEehMD6aOSNtVhfP8oirjFIIffRe0Wzw1MSDGkw+q1c4m0Yw5sEOlvA==
@@ -578,6 +596,25 @@
     "@celo/connect" "2.3.0"
     "@celo/utils" "2.3.0"
     "@celo/wallet-local" "2.3.0"
+    "@types/bn.js" "^5.1.0"
+    "@types/debug" "^4.1.5"
+    bignumber.js "^9.0.0"
+    cross-fetch "^3.0.6"
+    debug "^4.1.1"
+    fp-ts "2.1.1"
+    io-ts "2.0.1"
+    semver "^7.3.5"
+    web3 "1.3.6"
+
+"@celo/contractkit@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@celo/contractkit/-/contractkit-4.1.0.tgz#6e88edca10a67c90eaa5e58b64e0dda68a1df87e"
+  integrity sha512-JmlCMrU2o09zjA6hiRixdKzTTmwkm2STL39sraYD96JMJsywwnu300oRMEupDZN3HobwStKTuTnR8r+xGeWT9Q==
+  dependencies:
+    "@celo/base" "4.1.0"
+    "@celo/connect" "4.1.0"
+    "@celo/utils" "4.1.0"
+    "@celo/wallet-local" "4.1.0"
     "@types/bn.js" "^5.1.0"
     "@types/debug" "^4.1.5"
     bignumber.js "^9.0.0"
@@ -664,6 +701,23 @@
     web3-eth-abi "1.3.6"
     web3-utils "1.3.6"
 
+"@celo/utils@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@celo/utils/-/utils-4.1.0.tgz#ffbfedb8d5866af8d309b57a79dfb35870e368e8"
+  integrity sha512-N0ijAXAGFQavX75clVXhGOVTzSpv/AJmh+igYUCNVzyF0s/Ms/l9WjjEQsd0c3uWRkWBLXiKmCNTI9LZXazjkw==
+  dependencies:
+    "@celo/base" "4.1.0"
+    "@types/bn.js" "^5.1.0"
+    "@types/elliptic" "^6.4.9"
+    "@types/ethereumjs-util" "^5.2.0"
+    "@types/node" "^10.12.18"
+    bignumber.js "^9.0.0"
+    elliptic "^6.5.4"
+    ethereumjs-util "^5.2.0"
+    io-ts "2.0.1"
+    web3-eth-abi "1.3.6"
+    web3-utils "1.3.6"
+
 "@celo/wallet-base@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/wallet-base/-/wallet-base-1.5.2.tgz#ae8df425bf3c702277bb1b63a761a2ec8429e7aa"
@@ -694,6 +748,21 @@
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
 
+"@celo/wallet-base@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@celo/wallet-base/-/wallet-base-4.1.0.tgz#890ad567b73ad59ba7f8eb060372fd8ab8476bb7"
+  integrity sha512-fc6DGI6vcwGE/z3hT/7rZkQ9nvv/7l8RAEmof05zqMCdXdqaq135GWuE5H7gcC/qCLJzRNVpPGcWAPKUQ4z03A==
+  dependencies:
+    "@celo/base" "4.1.0"
+    "@celo/connect" "4.1.0"
+    "@celo/utils" "4.1.0"
+    "@types/debug" "^4.1.5"
+    "@types/ethereumjs-util" "^5.2.0"
+    bignumber.js "^9.0.0"
+    debug "^4.1.1"
+    eth-lib "^0.2.8"
+    ethereumjs-util "^5.2.0"
+
 "@celo/wallet-local@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@celo/wallet-local/-/wallet-local-1.5.2.tgz#66ea5fb763e19724309e3d56f312f1a342e12b91"
@@ -714,6 +783,18 @@
     "@celo/connect" "2.3.0"
     "@celo/utils" "2.3.0"
     "@celo/wallet-base" "2.3.0"
+    "@types/ethereumjs-util" "^5.2.0"
+    eth-lib "^0.2.8"
+    ethereumjs-util "^5.2.0"
+
+"@celo/wallet-local@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@celo/wallet-local/-/wallet-local-4.1.0.tgz#e75ffb44f0352585db13f823034230d14064af1e"
+  integrity sha512-nG7f77gblF3CQ3811LOtmoLr8yC+f+G6QjkgUV9GmFNBDdUNQZf7OM1ZQaYib10D6OwY0UPxlP9N+tweVWDOdA==
+  dependencies:
+    "@celo/connect" "4.1.0"
+    "@celo/utils" "4.1.0"
+    "@celo/wallet-base" "4.1.0"
     "@types/ethereumjs-util" "^5.2.0"
     eth-lib "^0.2.8"
     ethereumjs-util "^5.2.0"
@@ -1157,7 +1238,7 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/rlp" "^5.5.0"
 
-"@ethersproject/address@5.7.0", "@ethersproject/address@^5.7.0":
+"@ethersproject/address@5.7.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
   integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
@@ -2105,6 +2186,22 @@
   version "0.3.0-beta.13"
   resolved "https://registry.yarnpkg.com/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz#b96086ff768ddf69928984d5eb0a8d78cfca9366"
   integrity sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==
+
+"@nomiclabs/hardhat-etherscan@^3.1.6":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.7.tgz#72e3d5bd5d0ceb695e097a7f6f5ff6fcbf062b9a"
+  integrity sha512-tZ3TvSgpvsQ6B6OGmo1/Au6u8BrAkvs1mIC/eURA3xgIfznUZBhmpne8hv7BXUzw9xNL3fXdpOYgOQlVMTcoHQ==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^8.1.0"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    lodash "^4.17.11"
+    semver "^6.3.0"
+    table "^6.8.0"
+    undici "^5.14.0"
 
 "@nomiclabs/hardhat-waffle@^2.0.2":
   version "2.0.3"
@@ -3506,6 +3603,16 @@ ajv@^8.0.0, ajv@^8.6.3:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
   integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.0.1:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -5016,6 +5123,13 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "^4.3.0"
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 bytes@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
@@ -5186,6 +5300,13 @@ cbor@^5.2.0:
   dependencies:
     bignumber.js "^9.0.1"
     nofilter "^1.0.4"
+
+cbor@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
 
 chai-as-promised@^7.1.0:
   version "7.1.1"
@@ -10184,6 +10305,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
+
 lodash.values@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
@@ -11139,6 +11265,11 @@ nofilter@^1.0.3, nofilter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
   integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
+
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@3.x:
   version "3.0.6"
@@ -13506,6 +13637,11 @@ stream-to-pull-stream@^1.7.1:
     looper "^3.0.0"
     pull-stream "^3.2.3"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -13837,6 +13973,17 @@ table@^5.2.3:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+table@^6.8.0:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tape@^4.4.0, tape@^4.6.3:
   version "4.15.0"
@@ -14482,6 +14629,13 @@ underscore@>1.4.4:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
   integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
+
+undici@^5.14.0:
+  version "5.23.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.23.0.tgz#e7bdb0ed42cebe7b7aca87ced53e6eaafb8f8ca0"
+  integrity sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==
+  dependencies:
+    busboy "^1.6.0"
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description

This PR allows Celo's core Governance to execute arbitrary transactions as the stCELO MultiSig, essentially giving Celo Governance co-ownership of the stCELO protocol. Thus, Celo Governance referenda and hotfixes can affect the stCELO contracts (in particular, hotfixes can be used for rapid response to any emergencies that may come up).

### Other changes

* Created UsingRegistryNoStorage helper contract. MultiSig needs to be able to access the Celo Registry to grab Governance's address, but we can't use the available UsingRegistryUpgreadable, as inheriting from it would introduce a new storage slot, that would mangle MultiSig's storage. UsingRegistryNoStorage stores the Registry's canonical address (`0xce10`) as a constant, and thus needs no actual storage slots. This is similar to the UsingRegistryV2 in the monorepo.

* Drive-by: removed the `ProposalExecuted` event as it is not used anywhere.

### Tested

Unit tests.

### Related issues

- Fixes #158 
