### PR TITLE
Test cleanup: `before`, snapshots, multisig and validator utils

### DIFF
--- a/test-ts/account.test.ts
+++ b/test-ts/account.test.ts
@@ -29,6 +29,9 @@ after(() => {
 });
 
 describe("Account", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
   let accountsInstance: AccountsWrapper;
   let lockedGold: LockedGoldWrapper;
   let election: ElectionWrapper;
@@ -85,6 +88,7 @@ describe("Account", () => {
   });
 
   beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
     await hre.deployments.fixture("TestAccount");
     owner = await hre.ethers.getNamedSigner("owner");
     pauser = owner;
@@ -92,6 +96,10 @@ describe("Account", () => {
     await account.connect(owner).setManager(manager.address);
     await account.connect(owner).setPauser();
     governance = await hre.ethers.getContract("MockGovernance");
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
   });
 
   it("should create an account on the core Accounts contract", async () => {

--- a/test-ts/account.test.ts
+++ b/test-ts/account.test.ts
@@ -17,12 +17,11 @@ import {
   LOCKED_GOLD_UNLOCKING_PERIOD,
   mineToNextEpoch,
   randomSigner,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   REGISTRY_ADDRESS,
   resetNetwork,
   timeTravel,
 } from "./utils";
+import { registerValidatorAndAddToGroupMembers, registerValidatorGroup } from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/account.test.ts
+++ b/test-ts/account.test.ts
@@ -82,13 +82,6 @@ describe("Account", () => {
       await registerValidatorAndAddToGroupMembers(groups[i], validators[i], validatorWallet);
     }
 
-    accountsInstance = await hre.kit.contracts.getAccounts();
-    lockedGold = await hre.kit.contracts.getLockedGold();
-    election = await hre.kit.contracts.getElection();
-  });
-
-  beforeEach(async () => {
-    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
     await hre.deployments.fixture("TestAccount");
     owner = await hre.ethers.getNamedSigner("owner");
     pauser = owner;
@@ -96,6 +89,14 @@ describe("Account", () => {
     await account.connect(owner).setManager(manager.address);
     await account.connect(owner).setPauser();
     governance = await hre.ethers.getContract("MockGovernance");
+
+    accountsInstance = await hre.kit.contracts.getAccounts();
+    lockedGold = await hre.kit.contracts.getLockedGold();
+    election = await hre.kit.contracts.getElection();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
   });
 
   afterEach(async () => {

--- a/test-ts/address-sorted-linked-list.test.ts
+++ b/test-ts/address-sorted-linked-list.test.ts
@@ -12,6 +12,9 @@ after(() => {
 });
 
 describe("AddressSortedLinkedList", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
   let addressSortedLinkedList: MockAddressSortedLinkedList;
   let accounts: string[] = [];
 
@@ -24,6 +27,8 @@ describe("AddressSortedLinkedList", () => {
   });
 
   beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
+
     const Lib = await hre.ethers.getContractFactory("AddressSortedLinkedList");
     const lib = await Lib.deploy();
     await lib.deployed();
@@ -36,6 +41,10 @@ describe("AddressSortedLinkedList", () => {
       })) as MockAddressSortedLinkedList__factory;
     addressSortedLinkedList = await addressSortedLinkedListFactory.deploy();
     accounts = await hre.web3.eth.getAccounts();
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("#insert()", () => {

--- a/test-ts/address-sorted-linked-list.test.ts
+++ b/test-ts/address-sorted-linked-list.test.ts
@@ -24,10 +24,6 @@ describe("AddressSortedLinkedList", () => {
     } catch (error) {
       console.error(error);
     }
-  });
-
-  beforeEach(async () => {
-    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
 
     const Lib = await hre.ethers.getContractFactory("AddressSortedLinkedList");
     const lib = await Lib.deploy();
@@ -41,6 +37,10 @@ describe("AddressSortedLinkedList", () => {
       })) as MockAddressSortedLinkedList__factory;
     addressSortedLinkedList = await addressSortedLinkedListFactory.deploy();
     accounts = await hre.web3.eth.getAccounts();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
   });
 
   afterEach(async () => {

--- a/test-ts/default-strategy.test.ts
+++ b/test-ts/default-strategy.test.ts
@@ -43,7 +43,6 @@ import {
   electGroup,
   electMockValidatorGroupsAndUpdate,
   registerValidatorAndAddToGroupMembers,
-  registerValidatorAndOnlyAffiliateToGroup,
   registerValidatorGroup,
   removeMembersFromGroup,
   updateGroupSlashingMultiplier,

--- a/test-ts/default-strategy.test.ts
+++ b/test-ts/default-strategy.test.ts
@@ -25,27 +25,29 @@ import { MockVote } from "../typechain-types/MockVote";
 import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
 import {
   ADDRESS_ZERO,
-  deregisterValidatorGroup,
-  electGroup,
-  electMockValidatorGroupsAndUpdate,
   getDefaultGroups,
   getOrderedActiveGroups,
   getUnsortedGroups,
   mineToNextEpoch,
   prepareOverflow,
   randomSigner,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorAndOnlyAffiliateToGroup,
-  registerValidatorGroup,
   REGISTRY_ADDRESS,
-  removeMembersFromGroup,
   resetNetwork,
   revokeElectionOnMockValidatorGroupsAndUpdate,
   updateGroupCeloBasedOnProtocolStCelo,
-  updateGroupSlashingMultiplier,
   updateMaxNumberOfGroups,
 } from "./utils";
 import { OrderedGroup } from "./utils-interfaces";
+import {
+  deregisterValidatorGroup,
+  electGroup,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorAndOnlyAffiliateToGroup,
+  registerValidatorGroup,
+  removeMembersFromGroup,
+  updateGroupSlashingMultiplier,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/end-to-end-overflow.test.ts
+++ b/test-ts/end-to-end-overflow.test.ts
@@ -125,7 +125,7 @@ describe("e2e overflow test", () => {
     await activateValidators(
       defaultStrategy,
       groupHealthContract as unknown as GroupHealth,
-      multisigOwner0.address,
+      multisigOwner0,
       activatedGroupAddresses
     );
   });

--- a/test-ts/end-to-end-overflow.test.ts
+++ b/test-ts/end-to-end-overflow.test.ts
@@ -14,15 +14,17 @@ import { MockGroupHealth } from "../typechain-types/MockGroupHealth";
 import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
 import {
   activateAndVoteTest,
-  activateValidators,
-  electMockValidatorGroupsAndUpdate,
   prepareOverflow,
   randomSigner,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   resetNetwork,
   upgradeToMockGroupHealthE2E,
 } from "./utils";
+import {
+  activateValidators,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/end-to-end-specific-group-strategy.test.ts
+++ b/test-ts/end-to-end-specific-group-strategy.test.ts
@@ -156,7 +156,7 @@ describe("e2e specific group strategy voting", () => {
     await activateValidators(
       defaultStrategy,
       groupHealthContract as unknown as GroupHealth,
-      multisigOwner0.address,
+      multisigOwner0,
       activatedGroupAddresses
     );
   });

--- a/test-ts/end-to-end-specific-group-strategy.test.ts
+++ b/test-ts/end-to-end-specific-group-strategy.test.ts
@@ -15,9 +15,7 @@ import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy"
 import { StakedCelo } from "../typechain-types/StakedCelo";
 import {
   activateAndVoteTest,
-  activateValidators,
   distributeEpochRewards,
-  electMockValidatorGroupsAndUpdate,
   getGroupsOfAllStrategies,
   getRealVsExpectedCeloForGroups,
   LOCKED_GOLD_UNLOCKING_PERIOD,
@@ -25,13 +23,17 @@ import {
   randomSigner,
   rebalanceDefaultGroups,
   rebalanceGroups,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   resetNetwork,
   revokeElectionOnMockValidatorGroupsAndUpdate,
   timeTravel,
   upgradeToMockGroupHealthE2E,
 } from "./utils";
+import {
+  activateValidators,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/end-to-end-vote-proposal.test.ts
+++ b/test-ts/end-to-end-vote-proposal.test.ts
@@ -17,18 +17,20 @@ import { StakedCelo } from "../typechain-types/StakedCelo";
 import { Vote } from "../typechain-types/Vote";
 import {
   activateAndVoteTest,
-  activateValidators,
   distributeEpochRewards,
-  electMockValidatorGroupsAndUpdate,
   impersonateAccount,
   mineToNextEpoch,
   randomSigner,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   resetNetwork,
   timeTravel,
   upgradeToMockGroupHealthE2E,
 } from "./utils";
+import {
+  activateValidators,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/end-to-end-vote-proposal.test.ts
+++ b/test-ts/end-to-end-vote-proposal.test.ts
@@ -133,7 +133,7 @@ describe("e2e governance vote", () => {
     await activateValidators(
       defaultStrategyContract,
       groupHealthContract as unknown as GroupHealth,
-      multisigOwner0.address,
+      multisigOwner0,
       activatedGroupAddresses
     );
   });

--- a/test-ts/end-to-end.test.ts
+++ b/test-ts/end-to-end.test.ts
@@ -12,20 +12,22 @@ import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy"
 import { StakedCelo } from "../typechain-types/StakedCelo";
 import {
   activateAndVoteTest,
-  activateValidators,
   distributeEpochRewards,
-  electMockValidatorGroupsAndUpdate,
   LOCKED_GOLD_UNLOCKING_PERIOD,
   mineToNextEpoch,
   randomSigner,
   rebalanceDefaultGroups,
   rebalanceGroups,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   resetNetwork,
   timeTravel,
   upgradeToMockGroupHealthE2E,
 } from "./utils";
+import {
+  activateValidators,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/end-to-end.test.ts
+++ b/test-ts/end-to-end.test.ts
@@ -121,7 +121,7 @@ describe("e2e", () => {
     await activateValidators(
       defaultStrategyContract,
       groupHealthContract as unknown as GroupHealth,
-      multisigOwner0.address,
+      multisigOwner0,
       activatedGroupAddresses
     );
   });

--- a/test-ts/group-health.test.ts
+++ b/test-ts/group-health.test.ts
@@ -14,18 +14,20 @@ import { MockRegistry } from "../typechain-types/MockRegistry";
 import { MockValidators } from "../typechain-types/MockValidators";
 import {
   ADDRESS_ZERO,
-  deregisterValidatorGroup,
-  electMockValidatorGroupsAndUpdate,
   mineToNextEpoch,
   randomSigner,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   REGISTRY_ADDRESS,
-  removeMembersFromGroup,
   resetNetwork,
   revokeElectionOnMockValidatorGroupsAndUpdate,
-  updateGroupSlashingMultiplier,
 } from "./utils";
+import {
+  deregisterValidatorGroup,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+  removeMembersFromGroup,
+  updateGroupSlashingMultiplier,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/manager.test.ts
+++ b/test-ts/manager.test.ts
@@ -25,7 +25,6 @@ import { MockVote } from "../typechain-types/MockVote";
 import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
 import {
   ADDRESS_ZERO,
-  electMockValidatorGroupsAndUpdate,
   getDefaultGroups,
   getImpersonatedSigner,
   getSpecificGroups,
@@ -33,14 +32,17 @@ import {
   prepareOverflow,
   randomSigner,
   rebalanceDefaultGroups,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   REGISTRY_ADDRESS,
   resetNetwork,
   revokeElectionOnMockValidatorGroupsAndUpdate,
   updateGroupCeloBasedOnProtocolStCelo,
-  updateGroupSlashingMultiplier,
 } from "./utils";
+import {
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+  updateGroupSlashingMultiplier,
+} from "./utils-validators";
 
 const sum = (xs: BigNumber[]): BigNumber => xs.reduce((a, b) => a.add(b));
 

--- a/test-ts/multisig.test.ts
+++ b/test-ts/multisig.test.ts
@@ -91,6 +91,9 @@ async function multiSigInitialize(owners: string[], requiredSignatures: number) 
 }
 
 describe("MultiSig", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
   let multiSig: MultiSig;
   let owner1: SignerWithAddress;
   let owner2: SignerWithAddress;
@@ -105,6 +108,8 @@ describe("MultiSig", () => {
   const delay = 7 * DAY;
 
   beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
+
     await hre.deployments.fixture("TestMultiSig");
     multiSig = await hre.ethers.getContract("MultiSig");
     await hre.deployments.fixture("TestPausable");
@@ -122,6 +127,10 @@ describe("MultiSig", () => {
     );
 
     owners = [owner1.address, owner2.address];
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("#constructor", () => {

--- a/test-ts/multisig.test.ts
+++ b/test-ts/multisig.test.ts
@@ -107,9 +107,7 @@ describe("MultiSig", () => {
   const requiredSignatures = 2;
   const delay = 7 * DAY;
 
-  beforeEach(async () => {
-    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
-
+  before(async () => {
     await hre.deployments.fixture("TestMultiSig");
     multiSig = await hre.ethers.getContract("MultiSig");
     await hre.deployments.fixture("TestPausable");
@@ -127,6 +125,10 @@ describe("MultiSig", () => {
     );
 
     owners = [owner1.address, owner2.address];
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
   });
 
   afterEach(async () => {

--- a/test-ts/multisig.test.ts
+++ b/test-ts/multisig.test.ts
@@ -9,6 +9,10 @@ import { PausableTest } from "../typechain-types/PausableTest";
 import { ProposalTester } from "../typechain-types/ProposalTester";
 import { ADDRESS_ZERO, DAY, getImpersonatedSigner, randomSigner, timeTravel } from "./utils";
 
+after(() => {
+  hre.kit.stop();
+});
+
 /**
  * Invokes the multisig's submitProposal, waits for the confirmation event
  * and returns the generated proposalId.

--- a/test-ts/pausable.test.ts
+++ b/test-ts/pausable.test.ts
@@ -10,16 +10,25 @@ after(() => {
 });
 
 describe("Pausable", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
   let pausableTest: PausableTest;
   let pauser: SignerWithAddress;
   let nonPauser: SignerWithAddress;
 
   beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
+
     await hre.deployments.fixture("TestPausable");
     pausableTest = await hre.ethers.getContract("PausableTest");
     [pauser] = await randomSigner(parseUnits("100"));
     [nonPauser] = await randomSigner(parseUnits("100"));
     await pausableTest.setPauser(pauser.address);
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("#pause", () => {

--- a/test-ts/pausable.test.ts
+++ b/test-ts/pausable.test.ts
@@ -5,6 +5,10 @@ import hre from "hardhat";
 import { PausableTest } from "../typechain-types/PausableTest";
 import { ADDRESS_ZERO, randomSigner } from "./utils";
 
+after(() => {
+  hre.kit.stop();
+});
+
 describe("Pausable", () => {
   let pausableTest: PausableTest;
   let pauser: SignerWithAddress;

--- a/test-ts/pausable.test.ts
+++ b/test-ts/pausable.test.ts
@@ -17,14 +17,16 @@ describe("Pausable", () => {
   let pauser: SignerWithAddress;
   let nonPauser: SignerWithAddress;
 
-  beforeEach(async () => {
-    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
-
+  before(async () => {
     await hre.deployments.fixture("TestPausable");
     pausableTest = await hre.ethers.getContract("PausableTest");
     [pauser] = await randomSigner(parseUnits("100"));
     [nonPauser] = await randomSigner(parseUnits("100"));
     await pausableTest.setPauser(pauser.address);
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
   });
 
   afterEach(async () => {

--- a/test-ts/proxy-deploy.test.ts
+++ b/test-ts/proxy-deploy.test.ts
@@ -118,12 +118,14 @@ describe("Contract deployed via proxy", () => {
             const newImplementation = (await contractFactory.deploy()).address;
             const theProxy = await hre.ethers.getContract(`${test.contractName}_Proxy`);
 
-            await expect(submitAndExecuteMultiSigProposal(
-              [contract.address],
-              ["0"],
-              [contract.interface.encodeFunctionData("upgradeTo", [newImplementation])],
-              multisigOwner0
-            )).to.emit(theProxy, "Upgraded");
+            await expect(
+              submitAndExecuteMultiSigProposal(
+                [contract.address],
+                ["0"],
+                [contract.interface.encodeFunctionData("upgradeTo", [newImplementation])],
+                multisigOwner0
+              )
+            ).to.emit(theProxy, "Upgraded");
           });
         });
 

--- a/test-ts/proxy-deploy.test.ts
+++ b/test-ts/proxy-deploy.test.ts
@@ -4,7 +4,8 @@ import { expect } from "chai";
 import { Contract, ContractFactory } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import hre from "hardhat";
-import { randomAddress, randomSigner, submitAndExecuteProposal, waitForEvent } from "./utils";
+import { randomAddress, randomSigner } from "./utils";
+import { submitAndExecuteMultiSigProposal } from "./utils-multisig";
 
 interface ProxyDeployTestData {
   contractName: string;
@@ -103,11 +104,11 @@ describe("Contract deployed via proxy", () => {
 
         describe("when called by the owner", () => {
           it("can transfer ownership", async () => {
-            await submitAndExecuteProposal(
-              multisigOwner0.address,
+            await submitAndExecuteMultiSigProposal(
               [contract.address],
               ["0"],
-              [contract.interface.encodeFunctionData("transferOwnership", [newOwner.address])]
+              [contract.interface.encodeFunctionData("transferOwnership", [newOwner.address])],
+              multisigOwner0
             );
 
             expect(await contract.owner()).to.eq(newOwner.address);
@@ -115,15 +116,14 @@ describe("Contract deployed via proxy", () => {
 
           it("can update the implementation", async () => {
             const newImplementation = (await contractFactory.deploy()).address;
+            const theProxy = await hre.ethers.getContract(`${test.contractName}_Proxy`);
 
-            await submitAndExecuteProposal(
-              multisigOwner0.address,
+            await expect(submitAndExecuteMultiSigProposal(
               [contract.address],
               ["0"],
-              [contract.interface.encodeFunctionData("upgradeTo", [newImplementation])]
-            );
-
-            await waitForEvent(contract, "Upgraded", newImplementation);
+              [contract.interface.encodeFunctionData("upgradeTo", [newImplementation])],
+              multisigOwner0
+            )).to.emit(theProxy, "Upgraded");
           });
         });
 

--- a/test-ts/rebased-staked-celo.test.ts
+++ b/test-ts/rebased-staked-celo.test.ts
@@ -28,10 +28,6 @@ describe("RebasedStakedCelo", () => {
 
   before(async () => {
     await resetNetwork();
-  });
-
-  beforeEach(async () => {
-    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
 
     await hre.deployments.fixture("TestRebasedStakedCelo");
     rebasedStakedCelo = await hre.ethers.getContract("RebasedStakedCelo");
@@ -45,6 +41,10 @@ describe("RebasedStakedCelo", () => {
     [someone] = await randomSigner(parseUnits("1000"));
 
     await rebasedStakedCelo.connect(owner).setPauser();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
   });
 
   afterEach(async () => {

--- a/test-ts/rebased-staked-celo.test.ts
+++ b/test-ts/rebased-staked-celo.test.ts
@@ -8,6 +8,10 @@ import { MockStakedCelo } from "../typechain-types/MockStakedCelo";
 import { RebasedStakedCelo } from "../typechain-types/RebasedStakedCelo";
 import { ADDRESS_ZERO, randomSigner, resetNetwork } from "./utils";
 
+after(() => {
+  hre.kit.stop();
+});
+
 describe("RebasedStakedCelo", () => {
   let rebasedStakedCelo: RebasedStakedCelo;
   let stakedCelo: MockStakedCelo;

--- a/test-ts/rebased-staked-celo.test.ts
+++ b/test-ts/rebased-staked-celo.test.ts
@@ -13,6 +13,9 @@ after(() => {
 });
 
 describe("RebasedStakedCelo", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
   let rebasedStakedCelo: RebasedStakedCelo;
   let stakedCelo: MockStakedCelo;
   let account: MockAccount;
@@ -28,6 +31,8 @@ describe("RebasedStakedCelo", () => {
   });
 
   beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
+
     await hre.deployments.fixture("TestRebasedStakedCelo");
     rebasedStakedCelo = await hre.ethers.getContract("RebasedStakedCelo");
     stakedCelo = await hre.ethers.getContract("MockStakedCelo");
@@ -40,6 +45,10 @@ describe("RebasedStakedCelo", () => {
     [someone] = await randomSigner(parseUnits("1000"));
 
     await rebasedStakedCelo.connect(owner).setPauser();
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("#initialize()", () => {

--- a/test-ts/specific_group_strategy.test.ts
+++ b/test-ts/specific_group_strategy.test.ts
@@ -20,20 +20,22 @@ import { MockVote } from "../typechain-types/MockVote";
 import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
 import {
   ADDRESS_ZERO,
-  deregisterValidatorGroup,
-  electMockValidatorGroupsAndUpdate,
   getBlockedSpecificGroupStrategies,
   getDefaultGroups,
   getImpersonatedSigner,
   getSpecificGroups,
   prepareOverflow,
   randomSigner,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   resetNetwork,
   revokeElectionOnMockValidatorGroupsAndUpdate,
   updateGroupCeloBasedOnProtocolStCelo,
 } from "./utils";
+import {
+  deregisterValidatorGroup,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/staked-celo.test.ts
+++ b/test-ts/staked-celo.test.ts
@@ -11,6 +11,9 @@ after(() => {
 });
 
 describe("StakedCelo", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
   let stakedCelo: StakedCelo;
   let managerContract: MockManager;
 
@@ -30,6 +33,8 @@ describe("StakedCelo", () => {
   });
 
   beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
+
     await hre.deployments.fixture("TestStakedCelo");
     stakedCelo = await hre.ethers.getContract("StakedCelo");
     managerContract = await hre.ethers.getContract("MockManager");
@@ -46,6 +51,10 @@ describe("StakedCelo", () => {
     });
 
     await stakedCelo.connect(owner).setPauser();
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("#mint()", () => {

--- a/test-ts/staked-celo.test.ts
+++ b/test-ts/staked-celo.test.ts
@@ -30,10 +30,6 @@ describe("StakedCelo", () => {
     pauser = owner;
     [nonManager] = await randomSigner(parseUnits("100"));
     [anAccount] = await randomSigner(parseUnits("100"));
-  });
-
-  beforeEach(async () => {
-    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
 
     await hre.deployments.fixture("TestStakedCelo");
     stakedCelo = await hre.ethers.getContract("StakedCelo");
@@ -51,6 +47,10 @@ describe("StakedCelo", () => {
     });
 
     await stakedCelo.connect(owner).setPauser();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
   });
 
   afterEach(async () => {

--- a/test-ts/staked-celo.test.ts
+++ b/test-ts/staked-celo.test.ts
@@ -6,6 +6,10 @@ import { MockManager } from "../typechain-types/MockManager";
 import { StakedCelo } from "../typechain-types/StakedCelo";
 import { ADDRESS_ZERO, impersonateAccount, randomSigner, resetNetwork } from "./utils";
 
+after(() => {
+  hre.kit.stop();
+});
+
 describe("StakedCelo", () => {
   let stakedCelo: StakedCelo;
   let managerContract: MockManager;

--- a/test-ts/utils-interfaces.ts
+++ b/test-ts/utils-interfaces.ts
@@ -23,27 +23,6 @@ export interface ExpectVsReal {
   diff: EthersBigNumber;
 }
 
-export interface DefaultGroupContract extends BaseContract {
-  getNumberOfGroups(overrides?: CallOverrides): Promise<EthersBigNumber>;
-  getGroupsHead(
-    overrides?: CallOverrides
-  ): Promise<[string, string] & { head: string; previousAddress: string }>;
-  getGroupPreviousAndNext(
-    key: string,
-    overrides?: CallOverrides
-  ): Promise<[string, string] & { previousAddress: string; nextAddress: string }>;
-  activateGroup(
-    group: string,
-    lesser: string,
-    greater: string,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<ContractTransaction>;
-  addActivatableGroup(
-    group: string,
-    overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<ContractTransaction>;
-}
-
 export interface OrderedGroup {
   group: string;
   stCelo: string;

--- a/test-ts/utils-interfaces.ts
+++ b/test-ts/utils-interfaces.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-unused-vars */
-import {
-  BaseContract,
-  BigNumber as EthersBigNumber,
-  CallOverrides,
-  ContractTransaction,
-  Overrides,
-} from "ethers";
+import { BaseContract, BigNumber as EthersBigNumber, ContractTransaction, Overrides } from "ethers";
 
 export interface RebalanceContract extends BaseContract {
   rebalance(

--- a/test-ts/utils-multisig.ts
+++ b/test-ts/utils-multisig.ts
@@ -1,0 +1,24 @@
+import hre from "hardhat";
+import { BigNumberish, ContractTransaction, Signer } from "ethers";
+
+import { timeTravel } from "./utils";
+
+export async function submitAndExecuteMultiSigProposal(
+  destinations: string[],
+  values: BigNumberish[],
+  payloads: string[],
+  signer: Signer
+): Promise<ContractTransaction> {
+  const multiSig = await hre.ethers.getContract("MultiSig");
+  const tx = await multiSig.connect(signer).submitProposal(
+    destinations,
+    values,
+    payloads
+  );
+  const receipt = await tx.wait();
+  const event = receipt.events?.find((event: any) => event.event === "ProposalConfirmed");
+  // @ts-ignore - proposalId not a compiled member of event.args
+  const proposalId = event?.args.proposalId;
+  await timeTravel((await multiSig.delay()).toNumber());
+  return multiSig.connect(signer).executeProposal(proposalId);
+}

--- a/test-ts/utils-multisig.ts
+++ b/test-ts/utils-multisig.ts
@@ -1,6 +1,6 @@
-import hre from "hardhat";
 import { BigNumberish, ContractTransaction, Signer } from "ethers";
-
+import hre from "hardhat";
+import { ProposalConfirmedEvent } from "../typechain-types/MultiSig";
 import { timeTravel } from "./utils";
 
 export async function submitAndExecuteMultiSigProposal(
@@ -10,13 +10,11 @@ export async function submitAndExecuteMultiSigProposal(
   signer: Signer
 ): Promise<ContractTransaction> {
   const multiSig = await hre.ethers.getContract("MultiSig");
-  const tx = await multiSig.connect(signer).submitProposal(
-    destinations,
-    values,
-    payloads
-  );
+  const tx = await multiSig.connect(signer).submitProposal(destinations, values, payloads);
   const receipt = await tx.wait();
-  const event = receipt.events?.find((event: any) => event.event === "ProposalConfirmed");
+  const event = receipt.events?.find(
+    (event: ProposalConfirmedEvent) => event.event === "ProposalConfirmed"
+  );
   // @ts-ignore - proposalId not a compiled member of event.args
   const proposalId = event?.args.proposalId;
   await timeTravel((await multiSig.delay()).toNumber());

--- a/test-ts/utils-validators.ts
+++ b/test-ts/utils-validators.ts
@@ -1,0 +1,277 @@
+import { CeloTxReceipt } from "@celo/connect";
+import { stringToSolidityBytes } from "@celo/contractkit/lib/wrappers/BaseWrapper";
+import { ValidatorsWrapper } from "@celo/contractkit/lib/wrappers/Validators";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { default as BigNumber, default as BigNumberJs } from "bignumber.js";
+import { BigNumber as EthersBigNumber, Wallet } from "ethers";
+import { parseUnits } from "ethers/lib/utils";
+import hre, { kit } from "hardhat";
+import { DefaultStrategy } from "../typechain-types/DefaultStrategy";
+import { GroupHealth } from "../typechain-types/GroupHealth";
+import { MockGroupHealth } from "../typechain-types/MockGroupHealth";
+import { MockLockedGold } from "../typechain-types/MockLockedGold";
+import { MockRegistry } from "../typechain-types/MockRegistry";
+import { MockValidators } from "../typechain-types/MockValidators";
+import {
+  ADDRESS_ZERO,
+  DAY,
+  impersonateAccount,
+  mineToNextEpoch,
+  MIN_VALIDATOR_LOCKED_CELO,
+  submitAndExecuteProposal,
+  timeTravel,
+} from "./utils";
+
+// Locks the required CELO and registers as a validator group.
+export async function registerValidatorGroup(account: SignerWithAddress, members = 1) {
+  const accounts = await kit.contracts.getAccounts();
+  const tx = accounts.createAccount();
+  await tx.sendAndWaitForReceipt({
+    from: account.address,
+  });
+
+  const lockedGold = await kit.contracts.getLockedGold();
+
+  // lock up the minimum of 10k per validator
+  await lockedGold.lock().sendAndWaitForReceipt({
+    from: account.address,
+    value: EthersBigNumber.from(MIN_VALIDATOR_LOCKED_CELO).mul(members).toString(),
+  });
+
+  const validators = await kit.contracts.getValidators();
+
+  await (
+    await validators.registerValidatorGroup(new BigNumber("0"))
+  ).sendAndWaitForReceipt({
+    from: account.address,
+  });
+}
+
+// Locks the required CELO and registers as a validator in the group `groupAddress`
+export async function registerValidatorAndAddToGroupMembers(
+  group: SignerWithAddress,
+  validator: SignerWithAddress,
+  validatorWallet: Wallet
+) {
+  await registerValidatorAndOnlyAffiliateToGroup(group, validator, validatorWallet);
+  await addValidatorToGroupMembers(group, validator);
+}
+
+export async function registerValidatorAndOnlyAffiliateToGroup(
+  group: SignerWithAddress,
+  validator: SignerWithAddress,
+  validatorWallet: Wallet
+) {
+  const accounts = await kit.contracts.getAccounts();
+
+  await accounts.createAccount().sendAndWaitForReceipt({
+    from: validator.address,
+  });
+
+  const lockedGold = await kit.contracts.getLockedGold();
+
+  // lock up the 10k minimum
+  await lockedGold.lock().sendAndWaitForReceipt({
+    from: validator.address,
+    value: MIN_VALIDATOR_LOCKED_CELO,
+  });
+
+  const validators = await kit.contracts.getValidators();
+
+  // Validators.sol needs a 64 byte public key, the one stored in a Wallet is 65
+  // bytes. The first byte is unnecessary, and we also want to strip the leading
+  // 0x, so we `.slice(4)`.
+  const publicKey = validatorWallet.publicKey.slice(4);
+  // A random 64 byte hex string. Taken from the monorepo.
+  const blsPublicKey =
+    "0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00";
+  const blsPoP =
+    "0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900";
+
+  await validators.registerValidator(publicKey, blsPublicKey, blsPoP).sendAndWaitForReceipt({
+    from: validator.address,
+  });
+
+  // Affiliate validator with the group
+  await validators.affiliate(group.address).sendAndWaitForReceipt({
+    from: validator.address,
+  });
+}
+
+export async function addValidatorToGroupMembers(
+  group: SignerWithAddress,
+  validator: SignerWithAddress
+) {
+  const validators = await kit.contracts.getValidators();
+  const tx = await validators.addMember(group.address, validator.address);
+  await tx.sendAndWaitForReceipt({
+    from: group.address,
+  });
+}
+
+export async function removeMembersFromGroup(group: SignerWithAddress) {
+  // get validators contract
+  const validators = await kit.contracts.getValidators();
+
+  // get validator group
+  const validatorGroup = await validators.getValidatorGroup(group.address);
+
+  // deaffiliate then deregister
+  const txs: Promise<CeloTxReceipt>[] = [];
+  for (const validator of validatorGroup.members) {
+    const tx = validators.removeMember(validator).sendAndWaitForReceipt({ from: group.address });
+    txs.push(tx);
+  }
+
+  await Promise.all(txs);
+}
+
+export async function deregisterValidatorGroup(group: SignerWithAddress) {
+  const validators = await kit.contracts.getValidators();
+  await removeMembersFromGroup(group);
+  const groupRequirementEndTime = await validators.getGroupLockedGoldRequirements();
+
+  await timeTravel(groupRequirementEndTime.duration.toNumber() + 2 * DAY);
+
+  await (
+    await validators.deregisterValidatorGroup(group.address)
+  ).sendAndWaitForReceipt({ from: group.address });
+}
+
+export async function activateValidators(
+  defaultStrategyContract: DefaultStrategy,
+  groupHealthContract: GroupHealth,
+  multisigOwner: string,
+  groupAddresses: string[]
+) {
+  let [nextGroup] = await defaultStrategyContract.getGroupsTail();
+  for (let i = 0; i < groupAddresses.length; i++) {
+    const isGroupValid = await groupHealthContract.isGroupValid(groupAddresses[i]);
+    if (!isGroupValid) {
+      throw new Error(`Group ${groupAddresses[i]} is not valid group!`);
+    }
+    await submitAndExecuteProposal(
+      multisigOwner,
+      [defaultStrategyContract.address],
+      ["0"],
+      [
+        defaultStrategyContract.interface.encodeFunctionData("activateGroup", [
+          groupAddresses[i],
+          ADDRESS_ZERO,
+          nextGroup,
+        ]),
+      ]
+    );
+    nextGroup = groupAddresses[i];
+  }
+}
+
+export async function voteForGroup(groupAddress: string, voter: SignerWithAddress) {
+  const lockedGold = await kit.contracts.getLockedGold();
+  const election = await kit.contracts.getElection();
+  await lockedGold.lock().sendAndWaitForReceipt({
+    from: voter.address,
+    value: parseUnits("1").toString(),
+  });
+
+  const voteTx = await election.vote(groupAddress, new BigNumberJs(parseUnits("1").toString()));
+  await voteTx.sendAndWaitForReceipt({ from: voter.address });
+}
+
+export async function activateVotesForGroup(voter: SignerWithAddress) {
+  const election = await kit.contracts.getElection();
+  const activateTxs = await election.activate(voter.address);
+  const txs: Promise<CeloTxReceipt>[] = [];
+  for (let i = 0; i < activateTxs.length; i++) {
+    const tx = activateTxs[i].sendAndWaitForReceipt({ from: voter.address });
+    txs.push(tx);
+  }
+  await Promise.all(txs);
+}
+
+export async function electGroup(groupAddress: string, voter: SignerWithAddress) {
+  await voteForGroup(groupAddress, voter);
+  await mineToNextEpoch(kit.web3);
+  await activateVotesForGroup(voter);
+}
+
+export async function updateGroupSlashingMultiplier(
+  registryContract: MockRegistry,
+  lockedGoldContract: MockLockedGold,
+  validatorsContract: MockValidators,
+  group: SignerWithAddress,
+  mockSlasher: SignerWithAddress
+) {
+  const coreContractsOwnerAddr = await registryContract.owner();
+
+  await impersonateAccount(coreContractsOwnerAddr);
+  const coreContractsOwner = await hre.ethers.getSigner(coreContractsOwnerAddr);
+
+  await registryContract
+    .connect(coreContractsOwner)
+    .setAddressFor("MockSlasher", mockSlasher.address);
+
+  await lockedGoldContract.connect(coreContractsOwner).addSlasher("MockSlasher");
+  await validatorsContract.connect(mockSlasher).halveSlashingMultiplier(group.address);
+
+  await mineToNextEpoch(hre.web3);
+}
+
+export async function electMockValidatorGroupsAndUpdate(
+  validators: ValidatorsWrapper,
+  groupHealthContract: MockGroupHealth,
+  validatorGroups: string[],
+  revoke = false,
+  update = true,
+  makeOneValidatorGroupUseSigner = true
+): Promise<number[]> {
+  let validatorsProcessed = 0;
+  const mockedIndexes: number[] = [];
+
+  for (let j = 0; j < validatorGroups.length; j++) {
+    const validatorGroup = validatorGroups[j];
+    const isValidatorGroup = await validators.isValidatorGroup(validatorGroup);
+
+    if (isValidatorGroup) {
+      const validatorGroupDetail = await validators.getValidatorGroup(validatorGroup);
+      for (let i = 0; i < validatorGroupDetail.members.length; i++) {
+        const memberOriginalAccount = validatorGroupDetail.members[i];
+        const signer = makeOneValidatorGroupUseSigner
+          ? await makeValidatorUseSigner(memberOriginalAccount)
+          : memberOriginalAccount;
+        const mockIndex = validatorsProcessed++;
+        await groupHealthContract.setElectedValidator(mockIndex, revoke ? ADDRESS_ZERO : signer);
+        mockedIndexes.push(mockIndex);
+      }
+    }
+    if (update) {
+      await groupHealthContract.updateGroupHealth(validatorGroup);
+    }
+
+    makeOneValidatorGroupUseSigner = false;
+  }
+  return mockedIndexes;
+}
+
+async function makeValidatorUseSigner(validatorAddress: string) {
+  const newAccountWallet = hre.ethers.Wallet.createRandom();
+  const newSignerAddress = await newAccountWallet.getAddress();
+
+  const accounts = await hre.kit.contracts.getAccounts();
+
+  const pop = await accounts.generateProofOfKeyPossessionLocally(
+    validatorAddress,
+    newSignerAddress,
+    newAccountWallet.privateKey
+  );
+  const publicKey = stringToSolidityBytes(newAccountWallet.publicKey.slice(4));
+  const authWithPubKey = await accounts["contract"].methods.authorizeValidatorSignerWithPublicKey(
+    newSignerAddress,
+    pop.v,
+    pop.r,
+    pop.s,
+    publicKey
+  );
+  await authWithPubKey.send({ from: validatorAddress });
+  return newSignerAddress;
+}

--- a/test-ts/utils-validators.ts
+++ b/test-ts/utils-validators.ts
@@ -20,9 +20,7 @@ import {
   MIN_VALIDATOR_LOCKED_CELO,
   timeTravel,
 } from "./utils";
-import {
-  submitAndExecuteMultiSigProposal,
-} from "./utils-multisig";
+import { submitAndExecuteMultiSigProposal } from "./utils-multisig";
 
 // Locks the required CELO and registers as a validator group.
 export async function registerValidatorGroup(account: SignerWithAddress, members = 1) {

--- a/test-ts/utils.ts
+++ b/test-ts/utils.ts
@@ -1,14 +1,12 @@
-import { CeloTxReceipt } from "@celo/connect";
 import { AccountsWrapper } from "@celo/contractkit/lib/wrappers/Accounts";
-import { stringToSolidityBytes } from "@celo/contractkit/lib/wrappers/BaseWrapper";
 import { ElectionWrapper } from "@celo/contractkit/lib/wrappers/Election";
 import { LockedGoldWrapper } from "@celo/contractkit/lib/wrappers/LockedGold";
 import { ValidatorsWrapper } from "@celo/contractkit/lib/wrappers/Validators";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { default as BigNumber, default as BigNumberJs } from "bignumber.js";
+import { default as BigNumberJs } from "bignumber.js";
 import { BigNumber as EthersBigNumber, Contract, Wallet } from "ethers";
 import { formatEther, parseUnits } from "ethers/lib/utils";
-import hre, { ethers, kit } from "hardhat";
+import hre, { ethers } from "hardhat";
 import Web3 from "web3";
 import {
   ACCOUNT_ACTIVATE_AND_VOTE,
@@ -24,9 +22,6 @@ import { Manager } from "../typechain-types/Manager";
 import { MockAccount } from "../typechain-types/MockAccount";
 import { MockDefaultStrategy } from "../typechain-types/MockDefaultStrategy";
 import { MockGroupHealth } from "../typechain-types/MockGroupHealth";
-import { MockLockedGold } from "../typechain-types/MockLockedGold";
-import { MockRegistry } from "../typechain-types/MockRegistry";
-import { MockValidators } from "../typechain-types/MockValidators";
 import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
 import electionContractData from "./code/abi/electionAbi.json";
 import {
@@ -42,207 +37,10 @@ export const REGISTRY_ADDRESS = "0x000000000000000000000000000000000000ce10";
 // This is hardcoded into ganache
 export const BLOCKS_PER_EPOCH = 100;
 
-const MIN_VALIDATOR_LOCKED_CELO = Web3.utils.toWei("10000", "ether");
+export const MIN_VALIDATOR_LOCKED_CELO = Web3.utils.toWei("10000", "ether");
 const HOUR = 60 * 60;
 export const DAY = 24 * HOUR;
 export const LOCKED_GOLD_UNLOCKING_PERIOD = 3 * DAY;
-
-// ---- Validator utils ----
-
-// Locks the required CELO and registers as a validator group.
-export async function registerValidatorGroup(account: SignerWithAddress, members = 1) {
-  const accounts = await kit.contracts.getAccounts();
-  const tx = accounts.createAccount();
-  await tx.sendAndWaitForReceipt({
-    from: account.address,
-  });
-
-  const lockedGold = await kit.contracts.getLockedGold();
-
-  // lock up the minimum of 10k per validator
-  await lockedGold.lock().sendAndWaitForReceipt({
-    from: account.address,
-    value: EthersBigNumber.from(MIN_VALIDATOR_LOCKED_CELO).mul(members).toString(),
-  });
-
-  const validators = await kit.contracts.getValidators();
-
-  await (
-    await validators.registerValidatorGroup(new BigNumber("0"))
-  ).sendAndWaitForReceipt({
-    from: account.address,
-  });
-}
-
-// Locks the required CELO and registers as a validator in the group `groupAddress`
-export async function registerValidatorAndAddToGroupMembers(
-  group: SignerWithAddress,
-  validator: SignerWithAddress,
-  validatorWallet: Wallet
-) {
-  await registerValidatorAndOnlyAffiliateToGroup(group, validator, validatorWallet);
-  await addValidatorToGroupMembers(group, validator);
-}
-
-export async function registerValidatorAndOnlyAffiliateToGroup(
-  group: SignerWithAddress,
-  validator: SignerWithAddress,
-  validatorWallet: Wallet
-) {
-  const accounts = await kit.contracts.getAccounts();
-
-  await accounts.createAccount().sendAndWaitForReceipt({
-    from: validator.address,
-  });
-
-  const lockedGold = await kit.contracts.getLockedGold();
-
-  // lock up the 10k minimum
-  await lockedGold.lock().sendAndWaitForReceipt({
-    from: validator.address,
-    value: MIN_VALIDATOR_LOCKED_CELO,
-  });
-
-  const validators = await kit.contracts.getValidators();
-
-  // Validators.sol needs a 64 byte public key, the one stored in a Wallet is 65
-  // bytes. The first byte is unnecessary, and we also want to strip the leading
-  // 0x, so we `.slice(4)`.
-  const publicKey = validatorWallet.publicKey.slice(4);
-  // A random 64 byte hex string. Taken from the monorepo.
-  const blsPublicKey =
-    "0x4fa3f67fc913878b068d1fa1cdddc54913d3bf988dbe5a36a20fa888f20d4894c408a6773f3d7bde11154f2a3076b700d345a42fd25a0e5e83f4db5586ac7979ac2053cd95d8f2efd3e959571ceccaa743e02cf4be3f5d7aaddb0b06fc9aff00";
-  const blsPoP =
-    "0xcdb77255037eb68897cd487fdd85388cbda448f617f874449d4b11588b0b7ad8ddc20d9bb450b513bb35664ea3923900";
-
-  await validators.registerValidator(publicKey, blsPublicKey, blsPoP).sendAndWaitForReceipt({
-    from: validator.address,
-  });
-
-  // Affiliate validator with the group
-  await validators.affiliate(group.address).sendAndWaitForReceipt({
-    from: validator.address,
-  });
-}
-
-export async function addValidatorToGroupMembers(
-  group: SignerWithAddress,
-  validator: SignerWithAddress
-) {
-  const validators = await kit.contracts.getValidators();
-  const tx = await validators.addMember(group.address, validator.address);
-  await tx.sendAndWaitForReceipt({
-    from: group.address,
-  });
-}
-
-export async function removeMembersFromGroup(group: SignerWithAddress) {
-  // get validators contract
-  const validators = await kit.contracts.getValidators();
-
-  // get validator group
-  const validatorGroup = await validators.getValidatorGroup(group.address);
-
-  // deaffiliate then deregister
-  const txs: Promise<CeloTxReceipt>[] = [];
-  for (const validator of validatorGroup.members) {
-    const tx = validators.removeMember(validator).sendAndWaitForReceipt({ from: group.address });
-    txs.push(tx);
-  }
-
-  await Promise.all(txs);
-}
-
-export async function deregisterValidatorGroup(group: SignerWithAddress) {
-  const validators = await kit.contracts.getValidators();
-  await removeMembersFromGroup(group);
-  const groupRequirementEndTime = await validators.getGroupLockedGoldRequirements();
-
-  await timeTravel(groupRequirementEndTime.duration.toNumber() + 2 * DAY);
-
-  await (
-    await validators.deregisterValidatorGroup(group.address)
-  ).sendAndWaitForReceipt({ from: group.address });
-}
-
-export async function activateValidators(
-  defaultStrategyContract: DefaultStrategy,
-  groupHealthContract: GroupHealth,
-  multisigOwner: string,
-  groupAddresses: string[]
-) {
-  let [nextGroup] = await defaultStrategyContract.getGroupsTail();
-  for (let i = 0; i < groupAddresses.length; i++) {
-    const isGroupValid = await groupHealthContract.isGroupValid(groupAddresses[i]);
-    if (!isGroupValid) {
-      throw new Error(`Group ${groupAddresses[i]} is not valid group!`);
-    }
-    await submitAndExecuteProposal(
-      multisigOwner,
-      [defaultStrategyContract.address],
-      ["0"],
-      [
-        defaultStrategyContract.interface.encodeFunctionData("activateGroup", [
-          groupAddresses[i],
-          ADDRESS_ZERO,
-          nextGroup,
-        ]),
-      ]
-    );
-    nextGroup = groupAddresses[i];
-  }
-}
-
-export async function voteForGroup(groupAddress: string, voter: SignerWithAddress) {
-  const lockedGold = await kit.contracts.getLockedGold();
-  const election = await kit.contracts.getElection();
-  await lockedGold.lock().sendAndWaitForReceipt({
-    from: voter.address,
-    value: parseUnits("1").toString(),
-  });
-
-  const voteTx = await election.vote(groupAddress, new BigNumberJs(parseUnits("1").toString()));
-  await voteTx.sendAndWaitForReceipt({ from: voter.address });
-}
-
-export async function activateVotesForGroup(voter: SignerWithAddress) {
-  const election = await kit.contracts.getElection();
-  const activateTxs = await election.activate(voter.address);
-  const txs: Promise<CeloTxReceipt>[] = [];
-  for (let i = 0; i < activateTxs.length; i++) {
-    const tx = activateTxs[i].sendAndWaitForReceipt({ from: voter.address });
-    txs.push(tx);
-  }
-  await Promise.all(txs);
-}
-
-export async function electGroup(groupAddress: string, voter: SignerWithAddress) {
-  await voteForGroup(groupAddress, voter);
-  await mineToNextEpoch(kit.web3);
-  await activateVotesForGroup(voter);
-}
-
-export async function updateGroupSlashingMultiplier(
-  registryContract: MockRegistry,
-  lockedGoldContract: MockLockedGold,
-  validatorsContract: MockValidators,
-  group: SignerWithAddress,
-  mockSlasher: SignerWithAddress
-) {
-  const coreContractsOwnerAddr = await registryContract.owner();
-
-  await impersonateAccount(coreContractsOwnerAddr);
-  const coreContractsOwner = await hre.ethers.getSigner(coreContractsOwnerAddr);
-
-  await registryContract
-    .connect(coreContractsOwner)
-    .setAddressFor("MockSlasher", mockSlasher.address);
-
-  await lockedGoldContract.connect(coreContractsOwner).addSlasher("MockSlasher");
-  await validatorsContract.connect(mockSlasher).halveSlashingMultiplier(group.address);
-
-  await mineToNextEpoch(hre.web3);
-}
 
 // ---- Account utils ----
 
@@ -614,65 +412,6 @@ export async function rebalanceGroups(
   const expectedVsReal = await getRealVsExpectedCeloForGroups(managerContract, allGroups);
 
   await rebalanceInternal(managerContract, expectedVsReal);
-}
-
-export async function electMockValidatorGroupsAndUpdate(
-  validators: ValidatorsWrapper,
-  groupHealthContract: MockGroupHealth,
-  validatorGroups: string[],
-  revoke = false,
-  update = true,
-  makeOneValidatorGroupUseSigner = true
-): Promise<number[]> {
-  let validatorsProcessed = 0;
-  const mockedIndexes: number[] = [];
-
-  for (let j = 0; j < validatorGroups.length; j++) {
-    const validatorGroup = validatorGroups[j];
-    const isValidatorGroup = await validators.isValidatorGroup(validatorGroup);
-
-    if (isValidatorGroup) {
-      const validatorGroupDetail = await validators.getValidatorGroup(validatorGroup);
-      for (let i = 0; i < validatorGroupDetail.members.length; i++) {
-        const memberOriginalAccount = validatorGroupDetail.members[i];
-        const signer = makeOneValidatorGroupUseSigner
-          ? await makeValidatorUseSigner(memberOriginalAccount)
-          : memberOriginalAccount;
-        const mockIndex = validatorsProcessed++;
-        await groupHealthContract.setElectedValidator(mockIndex, revoke ? ADDRESS_ZERO : signer);
-        mockedIndexes.push(mockIndex);
-      }
-    }
-    if (update) {
-      await groupHealthContract.updateGroupHealth(validatorGroup);
-    }
-
-    makeOneValidatorGroupUseSigner = false;
-  }
-  return mockedIndexes;
-}
-
-async function makeValidatorUseSigner(validatorAddress: string) {
-  const newAccountWallet = hre.ethers.Wallet.createRandom();
-  const newSignerAddress = await newAccountWallet.getAddress();
-
-  const accounts = await hre.kit.contracts.getAccounts();
-
-  const pop = await accounts.generateProofOfKeyPossessionLocally(
-    validatorAddress,
-    newSignerAddress,
-    newAccountWallet.privateKey
-  );
-  const publicKey = stringToSolidityBytes(newAccountWallet.publicKey.slice(4));
-  const authWithPubKey = await accounts["contract"].methods.authorizeValidatorSignerWithPublicKey(
-    newSignerAddress,
-    pop.v,
-    pop.r,
-    pop.s,
-    publicKey
-  );
-  await authWithPubKey.send({ from: validatorAddress });
-  return newSignerAddress;
 }
 
 export async function revokeElectionOnMockValidatorGroupsAndUpdate(

--- a/test-ts/utils.ts
+++ b/test-ts/utils.ts
@@ -462,25 +462,10 @@ export async function upgradeToMockGroupHealthE2E(
     multisigOwner.address,
     [groupHealthContract.address],
     ["0"],
-    [groupHealthContract.interface.encodeFunctionData("upgradeTo", [mockGroupHealth.address])]
+    [groupHealthContract.interface.encodeFunctionData("upgradeTo", [mockGroupHealth.address])],
   );
 
   return mockGroupHealthFactory.attach(groupHealthContract.address);
-}
-
-export async function getIndexesOfElectedValidatorGroupMembers(
-  election: ElectionWrapper,
-  validators: ValidatorsWrapper,
-  validatorGroup: string
-) {
-  const validatorGroupDetail = await validators.getValidatorGroup(validatorGroup);
-  const currentValidatorSigners = await election.getCurrentValidatorSigners();
-  const finalIndexes: number[] = [];
-  for (const member of validatorGroupDetail.members) {
-    const index = currentValidatorSigners.indexOf(member);
-    finalIndexes.push(index === -1 ? currentValidatorSigners.length : index);
-  }
-  return finalIndexes;
 }
 
 export async function getOrderedActiveGroups(

--- a/test-ts/utils.ts
+++ b/test-ts/utils.ts
@@ -25,7 +25,6 @@ import { MockGroupHealth } from "../typechain-types/MockGroupHealth";
 import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
 import electionContractData from "./code/abi/electionAbi.json";
 import {
-  DefaultGroupContract,
   ExpectVsReal,
   OrderedGroup,
   RebalanceContract,
@@ -253,7 +252,7 @@ export async function setGovernanceConcurrentProposals(count: number) {
   });
 }
 
-export async function getDefaultGroups(defaultStrategy: DefaultGroupContract): Promise<string[]> {
+export async function getDefaultGroups(defaultStrategy: DefaultStrategy | MockDefaultStrategy): Promise<string[]> {
   const activeGroupsLengthPromise = defaultStrategy.getNumberOfGroups();
   let [key] = await defaultStrategy.getGroupsHead();
 
@@ -481,7 +480,7 @@ export async function getUnsortedGroups(defaultStrategyContract: MockDefaultStra
 }
 
 export async function prepareOverflow(
-  defaultStrategyContract: DefaultStrategy,
+  defaultStrategyContract: DefaultStrategy | MockDefaultStrategy,
   election: ElectionWrapper,
   lockedGold: LockedGoldWrapper,
   voter: SignerWithAddress,

--- a/test-ts/utils.ts
+++ b/test-ts/utils.ts
@@ -219,26 +219,6 @@ export async function submitAndExecuteProposal(
   }
 }
 
-export async function waitForEvent(
-  contract: Contract,
-  eventName: string,
-  expectedValue: string,
-  timeout = 10000
-) {
-  await new Promise<void>((resolve, reject) => {
-    setTimeout(() => {
-      reject(
-        `Event ${eventName} with expectedValue: ${expectedValue} wasn't emitted in timely manner.`
-      );
-    }, timeout);
-    contract.on(eventName, (implementation) => {
-      if (implementation == expectedValue) {
-        resolve();
-      }
-    });
-  });
-}
-
 export async function activateAndVoteTest(deployerAccountName = "deployer") {
   try {
     await hre.run(ACCOUNT_ACTIVATE_AND_VOTE, {

--- a/test-ts/utils.ts
+++ b/test-ts/utils.ts
@@ -4,7 +4,7 @@ import { LockedGoldWrapper } from "@celo/contractkit/lib/wrappers/LockedGold";
 import { ValidatorsWrapper } from "@celo/contractkit/lib/wrappers/Validators";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { default as BigNumberJs } from "bignumber.js";
-import { BigNumber as EthersBigNumber, Contract, Wallet } from "ethers";
+import { BigNumber as EthersBigNumber, Wallet } from "ethers";
 import { formatEther, parseUnits } from "ethers/lib/utils";
 import hre, { ethers } from "hardhat";
 import Web3 from "web3";
@@ -24,11 +24,7 @@ import { MockDefaultStrategy } from "../typechain-types/MockDefaultStrategy";
 import { MockGroupHealth } from "../typechain-types/MockGroupHealth";
 import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
 import electionContractData from "./code/abi/electionAbi.json";
-import {
-  ExpectVsReal,
-  OrderedGroup,
-  RebalanceContract,
-} from "./utils-interfaces";
+import { ExpectVsReal, OrderedGroup, RebalanceContract } from "./utils-interfaces";
 
 export const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
 export const REGISTRY_ADDRESS = "0x000000000000000000000000000000000000ce10";
@@ -252,7 +248,9 @@ export async function setGovernanceConcurrentProposals(count: number) {
   });
 }
 
-export async function getDefaultGroups(defaultStrategy: DefaultStrategy | MockDefaultStrategy): Promise<string[]> {
+export async function getDefaultGroups(
+  defaultStrategy: DefaultStrategy | MockDefaultStrategy
+): Promise<string[]> {
   const activeGroupsLengthPromise = defaultStrategy.getNumberOfGroups();
   let [key] = await defaultStrategy.getGroupsHead();
 
@@ -441,7 +439,7 @@ export async function upgradeToMockGroupHealthE2E(
     multisigOwner.address,
     [groupHealthContract.address],
     ["0"],
-    [groupHealthContract.interface.encodeFunctionData("upgradeTo", [mockGroupHealth.address])],
+    [groupHealthContract.interface.encodeFunctionData("upgradeTo", [mockGroupHealth.address])]
   );
 
   return mockGroupHealthFactory.attach(groupHealthContract.address);

--- a/test-ts/vote.test.ts
+++ b/test-ts/vote.test.ts
@@ -15,16 +15,18 @@ import { MockGroupHealth } from "../typechain-types/MockGroupHealth";
 import { Vote } from "../typechain-types/Vote";
 import {
   ADDRESS_ZERO,
-  electMockValidatorGroupsAndUpdate,
   getImpersonatedSigner,
   mineToNextEpoch,
   randomSigner,
-  registerValidatorAndAddToGroupMembers,
-  registerValidatorGroup,
   resetNetwork,
   setGovernanceConcurrentProposals,
   timeTravel,
 } from "./utils";
+import {
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+} from "./utils-validators";
 
 after(() => {
   hre.kit.stop();

--- a/test-ts/vote.test.ts
+++ b/test-ts/vote.test.ts
@@ -32,6 +32,9 @@ after(() => {
 
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-explicit-any
 describe("Vote", async function (this: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
   this.timeout(0); // Disable test timeout
   let managerContract: Manager;
   let groupHealthContract: MockGroupHealth;
@@ -170,6 +173,8 @@ describe("Vote", async function (this: any) {
   });
 
   beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
+
     await hre.deployments.fixture("TestVote");
     governanceWrapper = await hre.kit.contracts.getGovernance();
     managerContract = await hre.ethers.getContract("Manager");
@@ -213,6 +218,10 @@ describe("Vote", async function (this: any) {
         .activateGroup(activatedGroupAddresses[i], ADDRESS_ZERO, previousKey);
       previousKey = activatedGroupAddresses[i];
     }
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("#getVoteWeight()", () => {

--- a/test-ts/vote.test.ts
+++ b/test-ts/vote.test.ts
@@ -170,10 +170,6 @@ describe("Vote", async function (this: any) {
     } catch (error) {
       console.error(error);
     }
-  });
-
-  beforeEach(async () => {
-    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
 
     await hre.deployments.fixture("TestVote");
     governanceWrapper = await hre.kit.contracts.getGovernance();
@@ -218,6 +214,10 @@ describe("Vote", async function (this: any) {
         .activateGroup(activatedGroupAddresses[i], ADDRESS_ZERO, previousKey);
       previousKey = activatedGroupAddresses[i];
     }
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
   });
 
   afterEach(async () => {

--- a/test-ts/vote.test.ts
+++ b/test-ts/vote.test.ts
@@ -26,6 +26,10 @@ import {
   timeTravel,
 } from "./utils";
 
+after(() => {
+  hre.kit.stop();
+});
+
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-explicit-any
 describe("Vote", async function (this: any) {
   this.timeout(0); // Disable test timeout


### PR DESCRIPTION
### Description

Started doing some cleanup on the unit tests.

* There were inconsistencies in the use of `before`, `beforeEach`, and snapshots.
  * Now all unit test suites do all their top-level setup in a `before`
  * and use hardhat snapshots (in `before/afterEach`) to reset between unit tests.
* the `test-ts/utils.ts` file has become a monolith, started splitting it up into domain-specific files.

### Other changes

Removed `getIndexesOfElectedValidatorGroupMembers`, an unused function.

### Tested

Unit tests should still be passing.
