### PR TITLE
Add group validity check to rebalance() for consistency with changeStrategy()

### DIFF
--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -508,8 +508,11 @@ contract Manager is Errors, UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Pa
      * @param toGroup The to group.
      */
     function rebalance(address fromGroup, address toGroup) public onlyWhenNotPaused {
-        if (!defaultStrategy.isActive(toGroup) && specificGroupStrategy.isBlockedGroup(toGroup)) {
-            // rebalancing to deactivated/non-existent group is not allowed
+        if (
+            !defaultStrategy.isActive(toGroup) &&
+            (specificGroupStrategy.isBlockedGroup(toGroup) ||
+                !groupHealth.isGroupValid(toGroup))
+        ) {
             revert InvalidToGroup(toGroup);
         }
 

--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -510,8 +510,7 @@ contract Manager is Errors, UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Pa
     function rebalance(address fromGroup, address toGroup) public onlyWhenNotPaused {
         if (
             !defaultStrategy.isActive(toGroup) &&
-            (specificGroupStrategy.isBlockedGroup(toGroup) ||
-                !groupHealth.isGroupValid(toGroup))
+            (specificGroupStrategy.isBlockedGroup(toGroup) || !groupHealth.isGroupValid(toGroup))
         ) {
             revert InvalidToGroup(toGroup);
         }

--- a/test-ts/manager.test.ts
+++ b/test-ts/manager.test.ts
@@ -3193,13 +3193,13 @@ describe("Manager", () => {
       await account.setScheduledVotes(groupAddresses[0], fromGroupDepositedValue + 1);
 
       await expect(manager.rebalance(groupAddresses[0], ADDRESS_ZERO)).revertedWith(
-        `RebalanceEnoughCelo("${ADDRESS_ZERO}", 0, 0)`
+        `InvalidToGroup("${ADDRESS_ZERO}")`
       );
     });
 
     it("should revert when trying to balance 0x0 and 0x0 group", async () => {
       await expect(manager.rebalance(ADDRESS_ZERO, ADDRESS_ZERO)).revertedWith(
-        `RebalanceNoExtraCelo("${ADDRESS_ZERO}", 0, 0)`
+        `InvalidToGroup("${ADDRESS_ZERO}")`
       );
     });
 


### PR DESCRIPTION
rebalance() only checks isBlockedGroup(toGroup) for the destination, while changeStrategy() also checks !groupHealth.isGroupValid(toGroup). This adds the isGroupValid check to rebalance() so both functions apply the same destination validation.