### PR TITLE
fix: prevent stuck withdrawals when Election cap exhausts a group

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -1,11 +1,11 @@
 name: CI-Pipeline
 
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Triggers on push or pull request events for master and release branches.
   push:
-    branches: [master]
+    branches: [master, "releases/**"]
   pull_request:
-    branches: [master]
+    branches: [master, "releases/**"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -187,6 +187,17 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
     /// @notice There's no amount of scheduled withdrawal for the given beneficiary and group.
     error NoScheduledWithdrawal(address beneficiary, address group);
 
+    /**
+     * @notice Thrown when `rescueScheduledWithdrawal` targets a group that can
+     * still pay the beneficiary's withdrawal - so no rescue is warranted.
+     */
+    error GroupNotInDeficit(
+        address beneficiary,
+        address group,
+        uint256 capacity,
+        uint256 userClaim
+    );
+
     /// @notice Voting for proposal was not successfull.
     error VotingNotSuccessful(uint256 proposalId);
 
@@ -325,19 +336,19 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
             revert GroupsAndVotesArrayLengthsMismatch();
         }
 
+        // Thread one balance budget across groups: balance is shared, so
+        // validating each group independently would double-count the same CELO.
+        uint256 balanceBudget = address(this).balance;
         uint256 totalWithdrawalsDelta;
 
         for (uint256 i = 0; i < withdrawals.length; i++) {
-            uint256 celoAvailableForGroup = getCeloForGroup(groups[i]);
-            if (celoAvailableForGroup < withdrawals[i]) {
-                revert WithdrawalAmountTooHigh(groups[i], celoAvailableForGroup, withdrawals[i]);
-            }
-
-            scheduledVotes[groups[i]].toWithdraw += withdrawals[i];
-            scheduledVotes[groups[i]].toWithdrawFor[beneficiary] += withdrawals[i];
+            balanceBudget = _addBeneficiaryWithdrawal(
+                beneficiary,
+                groups[i],
+                withdrawals[i],
+                balanceBudget
+            );
             totalWithdrawalsDelta += withdrawals[i];
-
-            emit CeloWithdrawalScheduled(beneficiary, groups[i], withdrawals[i]);
         }
 
         totalScheduledWithdrawals += totalWithdrawalsDelta;
@@ -581,6 +592,60 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
     }
 
     /**
+     * @notice Re-routes a beneficiary's pinned withdrawal onto groups that can
+     * fulfill it, freeing CELO stuck on a group whose Election votes fell below
+     * the pinned amount. Bookkeeping only; no CELO moves. Permissionless, but
+     * only when `fromGroup` truly cannot pay this beneficiary right now (see
+     * `_requireGroupInDeficit`). Funds can only ever reach `beneficiary` via
+     * `Account.withdraw`, so a caller can at worst route to slower groups -
+     * never steal or destroy CELO.
+     * @dev Net change to `totalScheduledWithdrawals` is zero, so it isn't
+     * touched. The source slot is cleared before the additions, so passing
+     * `fromGroup` inside `toGroups` re-adds onto a clean slot instead of
+     * zeroing the beneficiary's claim.
+     * @param beneficiary The beneficiary of the withdrawal.
+     * @param fromGroup The group the withdrawal is currently pinned to.
+     * @param toGroups Groups to re-route the withdrawal across.
+     * @param amounts Per-group CELO amounts. Sum must equal the pinned amount.
+     */
+    function rescueScheduledWithdrawal(
+        address beneficiary,
+        address fromGroup,
+        address[] calldata toGroups,
+        uint256[] calldata amounts
+    ) external onlyWhenNotPaused {
+        if (toGroups.length != amounts.length) {
+            revert GroupsAndVotesArrayLengthsMismatch();
+        }
+        uint256 original = scheduledVotes[fromGroup].toWithdrawFor[beneficiary];
+        if (original == 0) {
+            revert NoScheduledWithdrawal(beneficiary, fromGroup);
+        }
+        _requireGroupInDeficit(beneficiary, fromGroup, original);
+
+        // Clear source FIRST so a malformed `toGroups` containing
+        // `fromGroup` cannot trigger an "add-then-zero" sequence that
+        // would destroy the beneficiary's claim.
+        scheduledVotes[fromGroup].toWithdrawFor[beneficiary] = 0;
+        scheduledVotes[fromGroup].toWithdraw -= original;
+
+        uint256 balanceBudget = address(this).balance;
+        uint256 sum;
+        for (uint256 i = 0; i < toGroups.length; i++) {
+            balanceBudget = _addBeneficiaryWithdrawal(
+                beneficiary,
+                toGroups[i],
+                amounts[i],
+                balanceBudget
+            );
+            sum += amounts[i];
+        }
+        if (sum != original) {
+            revert TransferAmountMisalignment(original, sum);
+        }
+    }
+
+    /**
      * @notice Gets the total amount of CELO this contract controls. This is the
      * unlocked CELO balance of the contract plus the amount of LockedGold for this contract,
      * which included unvoting and voting LockedGold.
@@ -705,7 +770,7 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
             uint256
         )
     {
-        return (1, 2, 1, 0);
+        return (1, 2, 2, 0);
     }
 
     /**
@@ -762,6 +827,9 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
      * @notice Returns the total amount of CELO directed towards `group`. This is
      * the Unlocked CELO balance for `group` plus the combined amount in pending
      * and active votes made by this contract.
+     * @dev WARNING: includes `scheduledVotes.toVote` even when Election cap is
+     * exhausted and those votes can never be cast. For withdrawal-capacity
+     * decisions use `getRealisableCeloForGroup` instead.
      * @param group The address of the validator group.
      * @return The total amount of CELO directed towards `group`.
      */
@@ -775,6 +843,29 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
         }
 
         return 0;
+    }
+
+    /**
+     * @notice CELO for `group` that `Account.withdraw` can actually pay out now,
+     * unlike `getCeloForGroup` which counts `toVote` the Election cap may block.
+     * @dev Two buckets: revokable Election votes, and the `toVote` slice backed
+     * by current balance (withdraw pays that directly, no Election vote needed).
+     * Subtract queued `toRevoke` from the revoke bucket, and existing
+     * `toWithdraw` once from the total - withdraw is immediate-first, so a
+     * pending withdrawal costs one unit of total capacity, not one per bucket.
+     * @param group The address of the validator group.
+     * @return The realisable CELO for `group`.
+     */
+    function getRealisableCeloForGroup(address group) public view returns (uint256) {
+        uint256 revokable = getElection().getTotalVotesForGroupByAccount(group, address(this));
+        uint256 toRevoke = scheduledVotes[group].toRevoke;
+        uint256 revokableAvail = revokable > toRevoke ? revokable - toRevoke : 0;
+        uint256 toVote = scheduledVotes[group].toVote;
+        uint256 balance = address(this).balance;
+        uint256 immediateBucket = balance < toVote ? balance : toVote;
+        uint256 capacity = revokableAvail + immediateBucket;
+        uint256 toWithdraw = scheduledVotes[group].toWithdraw;
+        return capacity > toWithdraw ? capacity - toWithdraw : 0;
     }
 
     /**
@@ -944,6 +1035,71 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
 
         if (addToRevoke > 0) {
             emit RevocationScheduled(group, addToRevoke);
+        }
+    }
+
+    /**
+     * @notice Books a per-group withdrawal for `rescueScheduledWithdrawal`,
+     * reverting unless the group can realisably fulfill it. Returns the
+     * balance budget left after this pin's immediate draw.
+     */
+    function _addBeneficiaryWithdrawal(
+        address beneficiary,
+        address toGroup,
+        uint256 amount,
+        uint256 balanceBudget
+    ) private returns (uint256 newBalanceBudget) {
+        // Capacity = immediate bucket + revoke bucket, minus what existing
+        // pins on this group already claim (subtracted once - see
+        // getRealisableCeloForGroup). Charge the budget by this pin's immediate
+        // draw so a later group can't reuse the same balance.
+        uint256 immediate;
+        {
+            uint256 revokable = getElection().getTotalVotesForGroupByAccount(
+                toGroup,
+                address(this)
+            );
+            uint256 toRevoke = scheduledVotes[toGroup].toRevoke;
+            uint256 revokableAvail = revokable > toRevoke ? revokable - toRevoke : 0;
+            uint256 toVote = scheduledVotes[toGroup].toVote;
+            uint256 immediateBucket = balanceBudget < toVote ? balanceBudget : toVote;
+            uint256 capacity = revokableAvail + immediateBucket;
+            uint256 existingToWithdraw = scheduledVotes[toGroup].toWithdraw;
+            uint256 capacityForNew = capacity > existingToWithdraw
+                ? capacity - existingToWithdraw
+                : 0;
+            if (amount > capacityForNew) {
+                revert WithdrawalAmountTooHigh(toGroup, capacityForNew, amount);
+            }
+            immediate = amount < immediateBucket ? amount : immediateBucket;
+        }
+        scheduledVotes[toGroup].toWithdraw += amount;
+        scheduledVotes[toGroup].toWithdrawFor[beneficiary] += amount;
+        emit CeloWithdrawalScheduled(beneficiary, toGroup, amount);
+        return balanceBudget - immediate;
+    }
+
+    /**
+     * @notice Reverts unless `group` genuinely cannot pay `userClaim` to this
+     * beneficiary now - the gate that keeps `rescueScheduledWithdrawal`
+     * permissionless without letting anyone reroute a payable withdrawal.
+     * @dev Capacity is what `Account.withdraw(beneficiary, group)` could deliver
+     * for THIS claim: `min(balance, toVote) + revokable`. It deliberately
+     * ignores `toRevoke` and other beneficiaries' `toWithdraw` - withdraw isn't
+     * gated by those, so counting them could mark a payable group as deficient.
+     */
+    function _requireGroupInDeficit(
+        address beneficiary,
+        address group,
+        uint256 userClaim
+    ) private view {
+        uint256 revokable = getElection().getTotalVotesForGroupByAccount(group, address(this));
+        uint256 toVote = scheduledVotes[group].toVote;
+        uint256 balance = address(this).balance;
+        uint256 immediate = toVote < balance ? toVote : balance;
+        uint256 capacity = immediate + revokable;
+        if (capacity >= userClaim) {
+            revert GroupNotInDeficit(beneficiary, group, capacity, userClaim);
         }
     }
 }

--- a/contracts/Account.sol
+++ b/contracts/Account.sol
@@ -770,7 +770,7 @@ contract Account is UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Managed, I
             uint256
         )
     {
-        return (1, 2, 2, 0);
+        return (1, 2, 1, 0);
     }
 
     /**

--- a/contracts/DefaultStrategy.sol
+++ b/contracts/DefaultStrategy.sol
@@ -412,7 +412,7 @@ contract DefaultStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausable {
      * @return finalGroups The groups that were chosen for subtraction.
      * @return finalVotes The votes of chosen finalGroups.
      */
-    function generateWithdrawalVoteDistribution(uint256 celoAmount)
+    function generateWithdrawalVoteDistribution(uint256 celoAmount, bool isTransfer)
         external
         managerOrStrategy
         returns (address[] memory finalGroups, uint256[] memory finalVotes)
@@ -430,14 +430,22 @@ contract DefaultStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausable {
         uint256 groupsIndex;
 
         while (groupsIndex < maxGroupCount && celoAmount != 0 && votedGroup != address(0)) {
-            votes[groupsIndex] = Math.min(
-                Math.min(
-                    account.getCeloForGroup(votedGroup),
-                    IManager(manager).toCelo(stCeloInGroup[votedGroup])
-                ),
-                celoAmount
-            );
+            // Real withdrawals cap by realisable CELO so we never pin to a
+            // group that can't pay. Transfers (isTransfer) are accounting-only
+            // and the caller discards the votes, so they skip that cap.
+            uint256 stCeloAsCelo = IManager(manager).toCelo(stCeloInGroup[votedGroup]);
+            uint256 capacity = isTransfer
+                ? stCeloAsCelo
+                : Math.min(account.getRealisableCeloForGroup(votedGroup), stCeloAsCelo);
 
+            if (capacity == 0) {
+                // Nothing to take here; move to the next-smaller group without
+                // using a slot. (Re-reading HEAD would loop on this group.)
+                (, votedGroup, ) = activeGroups.get(votedGroup);
+                continue;
+            }
+
+            votes[groupsIndex] = Math.min(capacity, celoAmount);
             groups[groupsIndex] = votedGroup;
             celoAmount -= votes[groupsIndex];
             _updateGroupStCelo(
@@ -447,13 +455,31 @@ contract DefaultStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausable {
             );
             trySort(votedGroup, stCeloInGroup[votedGroup], false);
 
+            address previous = votedGroup;
             if (sorted) {
                 votedGroup = activeGroups.getHead();
             } else {
-                (, votedGroup, ) = activeGroups.get(votedGroup);
+                (, votedGroup, ) = activeGroups.get(previous);
             }
 
             groupsIndex++;
+
+            // Skip groups already chosen this call: when realisable (not
+            // stCelo) is the binding cap, a group's stCelo barely drops and it
+            // can resurface as HEAD, and emitting it twice would make
+            // scheduleWithdrawals revert. Walking toward smaller groups never
+            // skips an unchosen one (HEAD-down order).
+            bool chosen = true;
+            while (votedGroup != address(0) && chosen) {
+                chosen = false;
+                for (uint256 j = 0; j < groupsIndex; j++) {
+                    if (groups[j] == votedGroup) {
+                        chosen = true;
+                        (, votedGroup, ) = activeGroups.get(votedGroup);
+                        break;
+                    }
+                }
+            }
         }
 
         if (celoAmount != 0) {
@@ -627,7 +653,7 @@ contract DefaultStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausable {
             uint256
         )
     {
-        return (1, 2, 0, 0);
+        return (1, 3, 0, 0);
     }
 
     /**

--- a/contracts/DefaultStrategy.sol
+++ b/contracts/DefaultStrategy.sol
@@ -653,7 +653,7 @@ contract DefaultStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausable {
             uint256
         )
     {
-        return (1, 3, 0, 0);
+        return (1, 2, 0, 0);
     }
 
     /**

--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -333,7 +333,7 @@ contract Manager is Errors, UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Pa
             uint256
         )
     {
-        return (1, 3, 1, 1);
+        return (1, 3, 1, 0);
     }
 
     /**

--- a/contracts/Manager.sol
+++ b/contracts/Manager.sol
@@ -333,7 +333,7 @@ contract Manager is Errors, UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Pa
             uint256
         )
     {
-        return (1, 3, 1, 0);
+        return (1, 3, 1, 1);
     }
 
     /**
@@ -671,7 +671,7 @@ contract Manager is Errors, UUPSOwnableUpgradeable, UsingRegistryUpgradeable, Pa
                 .generateWithdrawalVoteDistribution(strategy, celoAmount, stCeloAmount, isTransfer);
         } else {
             (groupsWithdrawn, withdrawalsPerGroup) = defaultStrategy
-                .generateWithdrawalVoteDistribution(celoAmount);
+                .generateWithdrawalVoteDistribution(celoAmount, isTransfer);
         }
 
         return (groupsWithdrawn, withdrawalsPerGroup);

--- a/contracts/SpecificGroupStrategy.sol
+++ b/contracts/SpecificGroupStrategy.sol
@@ -279,7 +279,7 @@ contract SpecificGroupStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausa
             celoWithdrawalAmount -= celoToBeMovedFromDefaultStrategy;
 
             (address[] memory overflowGroups, uint256[] memory overflowVotes) = defaultStrategy
-                .generateWithdrawalVoteDistribution(celoToBeMovedFromDefaultStrategy);
+                .generateWithdrawalVoteDistribution(celoToBeMovedFromDefaultStrategy, isTransfer);
 
             handleWithdrawalOverflowAndUnhealthyAccounting(
                 group,
@@ -294,7 +294,11 @@ contract SpecificGroupStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausa
                     groups[i] = overflowGroups[i];
                     votes[i] = overflowVotes[i];
                 }
-                if (!isTransfer && account.getCeloForGroup(group) < celoWithdrawalAmount) {
+                if (
+                    !isTransfer && account.getRealisableCeloForGroup(group) < celoWithdrawalAmount
+                ) {
+                    // Use realisable (not getCeloForGroup) so we don't pin to a
+                    // group whose votes the Election cap won't let us revoke.
                     revert GroupNotBalanced(group);
                 }
                 groups[overflowGroups.length] = group;
@@ -466,7 +470,7 @@ contract SpecificGroupStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausa
             uint256
         )
     {
-        return (1, 1, 1, 0);
+        return (1, 1, 1, 1);
     }
 
     /**
@@ -623,8 +627,9 @@ contract SpecificGroupStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausa
      */
     function transferFromDefaultStrategy(address group, uint256 stCeloToMove) private {
         uint256 toMoveCelo = IManager(manager).toCelo(stCeloToMove);
+        // isTransfer=true: accounting-only move, so DS skips the realisable cap.
         (address[] memory fromGroups, uint256[] memory fromVotes) = defaultStrategy
-            .generateWithdrawalVoteDistribution(toMoveCelo);
+            .generateWithdrawalVoteDistribution(toMoveCelo, true);
         address[] memory toGroups = new address[](1);
         uint256[] memory toVotes = new uint256[](1);
         toGroups[0] = group;

--- a/contracts/SpecificGroupStrategy.sol
+++ b/contracts/SpecificGroupStrategy.sol
@@ -470,7 +470,7 @@ contract SpecificGroupStrategy is Errors, UUPSOwnableUpgradeable, Managed, Pausa
             uint256
         )
     {
-        return (1, 1, 1, 1);
+        return (1, 1, 1, 0);
     }
 
     /**

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -29,6 +29,8 @@ interface IAccount {
 
     function getCeloForGroup(address) external view returns (uint256);
 
+    function getRealisableCeloForGroup(address group) external view returns (uint256);
+
     function scheduledVotesForGroup(address group) external view returns (uint256);
 
     function scheduledRevokeForGroup(address group) external view returns (uint256);

--- a/contracts/interfaces/IDefaultStrategy.sol
+++ b/contracts/interfaces/IDefaultStrategy.sol
@@ -8,7 +8,7 @@ interface IDefaultStrategy {
         address depositGroupToIgnore
     ) external returns (address[] memory finalGroups, uint256[] memory finalVotes);
 
-    function generateWithdrawalVoteDistribution(uint256 celoAmount)
+    function generateWithdrawalVoteDistribution(uint256 celoAmount, bool isTransfer)
         external
         returns (address[] memory finalGroups, uint256[] memory finalVotes);
 

--- a/contracts/mock/MockAccount.sol
+++ b/contracts/mock/MockAccount.sol
@@ -22,6 +22,7 @@ contract MockAccount {
     address public lastWithdrawalBeneficiary;
 
     mapping(address => uint256) public getCeloForGroup;
+    mapping(address => uint256) public getRealisableCeloForGroup;
     uint256 public getTotalCelo;
 
     mapping(address => uint256) public scheduledVotesForGroup;
@@ -34,6 +35,15 @@ contract MockAccount {
     uint256 public yesVotesVoted;
     uint256 public noVotesVoted;
     uint256 public abstainVoteVoted;
+
+    /**
+     * @notice Used when attempting to schedule more withdrawals
+     * than CELO available to the contract.
+     * @param group The offending group.
+     * @param celoAvailable CELO available to the group.
+     * @param celoToWithdraw total amount of CELO that would be scheduled to be withdrawn.
+     */
+    error WithdrawalAmountTooHigh(address group, uint256 celoAvailable, uint256 celoToWithdraw);
 
     // solhint-disable-next-line no-empty-blocks
     receive() external payable {}
@@ -48,6 +58,15 @@ contract MockAccount {
         address[] calldata groups,
         uint256[] calldata withdrawals
     ) external {
+        // Validate that each group has enough CELO for the withdrawal
+        // This matches the validation in the real Account contract
+        for (uint256 i = 0; i < withdrawals.length; i++) {
+            uint256 celoAvailableForGroup = getRealisableCeloForGroup[groups[i]];
+            if (celoAvailableForGroup < withdrawals[i]) {
+                revert WithdrawalAmountTooHigh(groups[i], celoAvailableForGroup, withdrawals[i]);
+            }
+        }
+
         lastWithdrawnGroups = groups;
         lastWithdrawals = withdrawals;
         lastWithdrawalBeneficiary = beneficiary;
@@ -55,6 +74,12 @@ contract MockAccount {
 
     function setCeloForGroup(address group, uint256 amount) external {
         getCeloForGroup[group] = amount;
+        // Keep realisable in sync with legacy setter so existing tests pass.
+        getRealisableCeloForGroup[group] = amount;
+    }
+
+    function setRealisableCeloForGroup(address group, uint256 amount) external {
+        getRealisableCeloForGroup[group] = amount;
     }
 
     function setTotalCelo(uint256 amount) external {

--- a/scripts/_lesser_greater.py
+++ b/scripts/_lesser_greater.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Compute Election sorted-list lesser/greater neighbours for a group whose
+total vote count changes to `new_total`.
+
+Input file holds the two return arrays of
+`Election.getTotalVotesForEligibleValidatorGroups()` as printed by `cast call`:
+  line 1: [0xaddr, 0xaddr, ...]
+  line 2: [1234 [1.2e3], 5678 [5.6e3], ...]   (cast appends sci-notation hints)
+
+The Celo Election sorted LinkedList is descending by vote weight:
+  - greater = node immediately ABOVE the group's new slot (more votes)
+  - lesser  = node immediately BELOW the group's new slot (fewer votes)
+address(0) when no such neighbour exists.
+
+Usage: _lesser_greater.py <file> <group_addr> <new_total>
+Prints: "<greater> <lesser>"
+"""
+import re
+import sys
+
+ZERO = "0x0000000000000000000000000000000000000000"
+
+
+def main() -> None:
+    path = sys.argv[1]
+    group = sys.argv[2].lower()
+    new_total = int(sys.argv[3])
+
+    lines = [ln for ln in open(path).read().splitlines() if ln.strip()]
+    addrs = re.findall(r"0x[0-9a-fA-F]{40}", lines[0])
+    # Values line: take the leading integer of each comma-separated token,
+    # ignoring cast's "[1.2e3]" scientific-notation annotations.
+    val_line = lines[1].strip().lstrip("[").rstrip("]")
+    vals = []
+    for tok in val_line.split(","):
+        m = re.match(r"\s*(\d+)", tok)
+        if m:
+            vals.append(int(m.group(1)))
+
+    n = min(len(addrs), len(vals))
+    d = {addrs[i].lower(): vals[i] for i in range(n)}
+
+    others = sorted(
+        ((a, v) for a, v in d.items() if a != group),
+        key=lambda kv: -kv[1],
+    )
+    above = [a for a, v in others if v >= new_total]
+    below = [a for a, v in others if v < new_total]
+    greater = above[-1] if above else ZERO
+    lesser = below[0] if below else ZERO
+    print(f"{greater} {lesser}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release-stuck-withdrawal-fix.sh
+++ b/scripts/release-stuck-withdrawal-fix.sh
@@ -82,26 +82,35 @@ fi
 
 # ---------------------------------------------------------------------------
 echo "=== deploying the 4 new implementations ==="
-# Deploy creation bytecode; surface the cast error (and abort) on failure.
-deploy(){
+# Use an explicit, locally-incremented nonce from the PENDING count. forno's
+# 'latest' nonce can lag the sequencer, so cast's auto-nonce may submit a stale
+# value ("nonce too low"). Anchoring to pending once and incrementing per deploy
+# keeps the 5 sequential deploys in lock-step with the sequencer.
+DEPLOYER_ADDR=$(cast wallet address --private-key "$DEPLOY_KEY")
+NEXT_NONCE=$(( $(cast rpc --rpc-url "$RPC" eth_getTransactionCount "$DEPLOYER_ADDR" pending | tr -d '"') ))
+echo "  deployer $DEPLOYER_ADDR starting at nonce $NEXT_NONCE"
+# Deploy creation bytecode at the given nonce; echo the address or abort.
+# NOTE: nonce is passed in and incremented by the CALLER (this function runs in
+# a $(...) subshell, so an increment here would not reach the parent).
+deploy(){ # <bytecode> <nonce>
   local out addr
-  out=$(cast send --rpc-url "$RPC" --private-key "$DEPLOY_KEY" $SEND_EXTRA --create "$1" --json 2>/tmp/deploy-err.log)
+  out=$(cast send --rpc-url "$RPC" --private-key "$DEPLOY_KEY" $SEND_EXTRA --nonce "$2" --create "$1" --json 2>/tmp/deploy-err.log)
   addr=$(echo "$out" | jq -r '.contractAddress // empty' 2>/dev/null)
   if [ -z "$addr" ] || [ "$addr" = "null" ]; then
-    echo "DEPLOY FAILED:" >&2; tail -5 /tmp/deploy-err.log >&2; return 1
+    echo "DEPLOY FAILED (nonce $2):" >&2; tail -5 /tmp/deploy-err.log >&2; return 1
   fi
   echo "$addr"
 }
-A_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Account.sol/Account.json)") || exit 1
-M_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Manager.sol/Manager.json)") || exit 1
-S_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/SpecificGroupStrategy.sol/SpecificGroupStrategy.json)") || exit 1
-LIB=$(deploy "$(jq -r .bytecode artifacts/contracts/common/linkedlists/AddressSortedLinkedList.sol/AddressSortedLinkedList.json)") || exit 1
+A_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Account.sol/Account.json)" "$NEXT_NONCE") || exit 1; NEXT_NONCE=$((NEXT_NONCE+1))
+M_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Manager.sol/Manager.json)" "$NEXT_NONCE") || exit 1; NEXT_NONCE=$((NEXT_NONCE+1))
+S_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/SpecificGroupStrategy.sol/SpecificGroupStrategy.json)" "$NEXT_NONCE") || exit 1; NEXT_NONCE=$((NEXT_NONCE+1))
+LIB=$(deploy "$(jq -r .bytecode artifacts/contracts/common/linkedlists/AddressSortedLinkedList.sol/AddressSortedLinkedList.json)" "$NEXT_NONCE") || exit 1; NEXT_NONCE=$((NEXT_NONCE+1))
 # Link DefaultStrategy to the deployed library. The placeholder must be replaced
 # by the full 40-hex address (lowercased, 0x stripped, LEADING ZEROS PRESERVED).
 LIB_HEX=$(echo "${LIB#0x}" | tr 'A-Z' 'a-z')
 DBC=$(jq -r .bytecode artifacts/contracts/DefaultStrategy.sol/DefaultStrategy.json | sed "s/__\$[0-9a-f]*\$__/$LIB_HEX/g")
 case "$DBC" in *'__$'*) echo "ERROR: DefaultStrategy bytecode still has an unlinked library placeholder" >&2; exit 1;; esac
-D_IMPL=$(deploy "$DBC") || exit 1
+D_IMPL=$(deploy "$DBC" "$NEXT_NONCE") || exit 1; NEXT_NONCE=$((NEXT_NONCE+1))
 for v in "$A_IMPL:Account" "$M_IMPL:Manager" "$S_IMPL:SpecificGroupStrategy" "$D_IMPL:DefaultStrategy" "$LIB:AddressSortedLinkedList"; do
   [ -n "${v%%:*}" ] && [ "${v%%:*}" != null ] || { echo "deploy failed: ${v##*:}"; exit 1; }
   echo "  ${v##*:}: ${v%%:*}"

--- a/scripts/release-stuck-withdrawal-fix.sh
+++ b/scripts/release-stuck-withdrawal-fix.sh
@@ -131,21 +131,24 @@ echo "  CGP JSON -> /tmp/stcelo-fix-cgp.json"
 # ---------------------------------------------------------------------------
 if [ "$TARGET" = "mainnet" ]; then
   echo "=== verifying implementations on Celoscan + Blockscout ==="
-  printf 'module.exports = { "%s": "%s" };\n' "AddressSortedLinkedList" "$LIB" > /tmp/ds-libs.js
-  verify_celoscan(){ # <addr> [extra hardhat args...]
-    local a="$1"; shift
-    echo "  [Celoscan] $a"; npx hardhat verify --network celo "$a" "$@" 2>&1 | tail -3 || true; }
+  # Both via forge (uses local solc; no dependency on solc-bin.ethereum.org,
+  # which the hardhat-etherscan plugin needs and which can fail with DNS errors).
+  verify_celoscan(){ # <addr> <path:Contract> [extra forge args...]
+    local a="$1" cp="$2"; shift 2
+    echo "  [Celoscan] $a ($cp)"; forge verify-contract "$a" "$cp" \
+      --chain celo --etherscan-api-key "$CELO_SCAN_API_KEY" \
+      --compiler-version "$SOLC_VERSION" --evm-version "$EVM_VERSION" --watch "$@" 2>&1 | tail -3 || true; }
   verify_blockscout(){ # <addr> <path:Contract> [extra forge args...]
     local a="$1" cp="$2"; shift 2
     echo "  [Blockscout] $a ($cp)"; forge verify-contract "$a" "$cp" \
       --verifier blockscout --verifier-url "$BLOCKSCOUT_API" \
       --compiler-version "$SOLC_VERSION" --evm-version "$EVM_VERSION" --watch "$@" 2>&1 | tail -3 || true; }
 
-  verify_celoscan  "$LIB";    verify_blockscout "$LIB"    "$DS_LIB_PATH"
-  verify_celoscan  "$A_IMPL"; verify_blockscout "$A_IMPL" "contracts/Account.sol:Account"
-  verify_celoscan  "$M_IMPL"; verify_blockscout "$M_IMPL" "contracts/Manager.sol:Manager"
-  verify_celoscan  "$S_IMPL"; verify_blockscout "$S_IMPL" "contracts/SpecificGroupStrategy.sol:SpecificGroupStrategy"
-  verify_celoscan  "$D_IMPL" --libraries /tmp/ds-libs.js
+  verify_celoscan  "$LIB"    "$DS_LIB_PATH";                                  verify_blockscout "$LIB"    "$DS_LIB_PATH"
+  verify_celoscan  "$A_IMPL" "contracts/Account.sol:Account";                 verify_blockscout "$A_IMPL" "contracts/Account.sol:Account"
+  verify_celoscan  "$M_IMPL" "contracts/Manager.sol:Manager";                 verify_blockscout "$M_IMPL" "contracts/Manager.sol:Manager"
+  verify_celoscan  "$S_IMPL" "contracts/SpecificGroupStrategy.sol:SpecificGroupStrategy"; verify_blockscout "$S_IMPL" "contracts/SpecificGroupStrategy.sol:SpecificGroupStrategy"
+  verify_celoscan  "$D_IMPL" "contracts/DefaultStrategy.sol:DefaultStrategy" --libraries "$DS_LIB_PATH:$LIB"
   verify_blockscout "$D_IMPL" "contracts/DefaultStrategy.sol:DefaultStrategy" --libraries "$DS_LIB_PATH:$LIB"
 
   echo

--- a/scripts/release-stuck-withdrawal-fix.sh
+++ b/scripts/release-stuck-withdrawal-fix.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# release-stuck-withdrawal-fix.sh
+# ===============================
+# Releases the stuck-withdrawal fix by upgrading the four stCELO
+# implementations (Account, DefaultStrategy, SpecificGroupStrategy, Manager)
+# via a CELO GOVERNANCE proposal.
+#
+# The stCELO proxies are owned by the stCELO MultiSig, but the MultiSig exposes
+# `governanceProposeAndExecute(destinations, values, payloads)` gated by
+# `onlyGovernance` - so Celo Governance can execute a batch of calls through it
+# directly (no owner timelock). The release is therefore a single CGP
+# transaction: Governance -> MultiSig.governanceProposeAndExecute([4 proxies],
+# [0,0,0,0], [upgradeTo(newImpl) x4]).
+#
+# Modes:
+#   (default) FORK TEST - fork mainnet, deploy impls, impersonate Celo
+#             Governance, execute the proposal, and assert upgrades + that
+#             pre-existing storage is intact and new code is live.
+#   --emit-only - deploy impls against the fork (or a node) and print the CGP
+#             transaction (to / value / data) + a celocli-style JSON, without
+#             asserting. Use the deployed impl addresses from a real broadcast
+#             when filing the actual CGP.
+#
+# Requirements: anvil, cast, jq, python3, yarn (foundry in PATH or ~/.foundry/bin).
+# RPC: https://forno.celo.org (override via CELO_RPC_URL).
+set -uo pipefail
+export PATH="$HOME/.foundry/bin:$PATH"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODE="${1:-fork-test}"
+RPC_FORK="${CELO_RPC_URL:-https://forno.celo.org}"
+PORT=8591; RPC="http://127.0.0.1:${PORT}"
+GAS=25000000000; BIG=0x10000000000000000000000
+# anvil default funded key (deployer in the fork).
+PK=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+# --- mainnet addresses ---
+REGISTRY=0x000000000000000000000000000000000000ce10
+MULTISIG=0x78DaA21FcE4D30E74fF745Da3204764a0ad40179
+ACCOUNT=0x4aAD04D41FD7fd495503731C5a2579e19054C432
+MANAGER=0x0239b96D10a434a56CC9E09383077A0490cF9398
+DS=0x3A3ed74B1cC543D5EB323f70ac2F19977a0eA088
+SGS=0xb88af6EAc9cd146D8b03b66708EF76beBD937871
+IMPL_SLOT=0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+
+FAIL=0; pass(){ echo "  [PASS] $*"; }; fail(){ echo "  [FAIL] $*"; FAIL=$((FAIL+1)); }
+cleanup(){ pkill -f "anvil .*port ${PORT}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+start_anvil(){
+  anvil --fork-url "$RPC_FORK" --celo --port "$PORT" --host 127.0.0.1 \
+    --disable-code-size-limit --base-fee "$GAS" --gas-price "$GAS" >/tmp/anvil-release.log 2>&1 &
+  for i in $(seq 1 60); do cast block-number --rpc-url "$RPC" >/dev/null 2>&1 && return 0; sleep 1; done
+  echo "anvil failed to start"; tail -20 /tmp/anvil-release.log; exit 1
+}
+
+deploy(){ cast send --rpc-url "$RPC" --private-key "$PK" --legacy --gas-price "$GAS" --create "$1" --json 2>/dev/null | jq -r .contractAddress; }
+
+echo "=== compiling ==="
+yarn --silent compile >/tmp/release-compile.log 2>&1 || { echo "compile failed"; tail /tmp/release-compile.log; exit 1; }
+
+echo "=== starting anvil fork of $RPC_FORK ==="
+start_anvil
+echo "  forked block: $(cast block-number --rpc-url "$RPC")"
+
+echo "=== deploying the 4 new implementations ==="
+A_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Account.sol/Account.json)")
+M_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Manager.sol/Manager.json)")
+S_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/SpecificGroupStrategy.sol/SpecificGroupStrategy.json)")
+LIB=$(deploy "$(jq -r .bytecode artifacts/contracts/common/linkedlists/AddressSortedLinkedList.sol/AddressSortedLinkedList.json)")
+DBC=$(jq -r .bytecode artifacts/contracts/DefaultStrategy.sol/DefaultStrategy.json | sed "s/__\$[0-9a-f]*\$__/$(echo "${LIB#0x}" | tr 'A-Z' 'a-z')/g")
+D_IMPL=$(deploy "$DBC")
+for v in "$A_IMPL:Account" "$M_IMPL:Manager" "$S_IMPL:SpecificGroupStrategy" "$D_IMPL:DefaultStrategy"; do
+  [ -n "${v%%:*}" ] && [ "${v%%:*}" != null ] || { echo "deploy failed: ${v##*:}"; exit 1; }
+  echo "  ${v##*:} impl: ${v%%:*}"
+done
+echo "  (DefaultStrategy linked to AddressSortedLinkedList $LIB)"
+
+echo "=== building the governance proposal calldata ==="
+# Per-proxy upgradeTo(newImpl) payloads.
+P_ACC=$(cast calldata "upgradeTo(address)" "$A_IMPL")
+P_MGR=$(cast calldata "upgradeTo(address)" "$M_IMPL")
+P_SGS=$(cast calldata "upgradeTo(address)" "$S_IMPL")
+P_DS=$(cast calldata "upgradeTo(address)" "$D_IMPL")
+# The single CGP transaction: Governance -> MultiSig.governanceProposeAndExecute(...).
+DESTS="[$ACCOUNT,$DS,$SGS,$MANAGER]"
+VALUES="[0,0,0,0]"
+PAYLOADS="[$P_ACC,$P_DS,$P_SGS,$P_MGR]"
+GPE=$(cast calldata "governanceProposeAndExecute(address[],uint256[],bytes[])" "$DESTS" "$VALUES" "$PAYLOADS")
+echo "  CGP transaction:"
+echo "    to:    $MULTISIG"
+echo "    value: 0"
+echo "    data:  ${GPE:0:74}... (${#GPE} chars)"
+# celocli-style proposal JSON (raw form).
+PROPOSAL_JSON=$(cat <<JSON
+[
+  { "value": "0", "to": "$MULTISIG", "data": "$GPE" }
+]
+JSON
+)
+echo "$PROPOSAL_JSON" > /tmp/stcelo-fix-cgp.json
+echo "  wrote CGP JSON -> /tmp/stcelo-fix-cgp.json"
+
+if [ "$MODE" = "--emit-only" ]; then
+  echo; echo "emit-only mode: proposal built, not executed."
+  echo "NOTE: deploy the impls on mainnet (real broadcast) and substitute their"
+  echo "      addresses before filing the CGP."
+  exit 0
+fi
+
+echo "=== FORK TEST: execute the proposal as Celo Governance ==="
+GOV=$(cast call "$REGISTRY" "getAddressForStringOrDie(string)(address)" "Governance" --rpc-url "$RPC")
+echo "  Celo Governance: $GOV"
+# snapshot pre-existing storage
+A_TSW=$(cast call $ACCOUNT "totalScheduledWithdrawals()(uint256)" --rpc-url $RPC | awk '{print $1}')
+A_MGR=$(cast call $ACCOUNT "manager()(address)" --rpc-url $RPC)
+A_OWN=$(cast call $ACCOUNT "owner()(address)" --rpc-url $RPC)
+DS_TOTAL=$(cast call $DS "totalStCeloInStrategy()(uint256)" --rpc-url $RPC | awk '{print $1}')
+DS_MAXW=$(cast call $DS "maxGroupsToWithdrawFrom()(uint256)" --rpc-url $RPC | awk '{print $1}')
+SGS_LOCKED=$(cast call $SGS "totalStCeloLocked()(uint256)" --rpc-url $RPC | awk '{print $1}')
+
+cast rpc --rpc-url $RPC anvil_impersonateAccount "$GOV" >/dev/null
+cast rpc --rpc-url $RPC anvil_setBalance "$GOV" "$BIG" >/dev/null
+ST=$(cast send --rpc-url $RPC --from "$GOV" --unlocked --legacy --gas-price $GAS \
+  "$MULTISIG" "governanceProposeAndExecute(address[],uint256[],bytes[])" "$DESTS" "$VALUES" "$PAYLOADS" \
+  --json 2>/dev/null | jq -r '.status')
+[ "$ST" = "0x1" ] && pass "governanceProposeAndExecute succeeded (Governance executed the batch)" || fail "governance execute tx status=$ST"
+
+# impl slots updated
+norm(){ echo "$1" | tr 'A-Z' 'a-z' | sed 's/^0x0*//'; }
+for pair in "Account:$ACCOUNT:$A_IMPL" "Manager:$MANAGER:$M_IMPL" "SGS:$SGS:$S_IMPL" "DefaultStrategy:$DS:$D_IMPL"; do
+  n=$(echo "$pair"|cut -d: -f1); a=$(echo "$pair"|cut -d: -f2); ex=$(echo "$pair"|cut -d: -f3)
+  got=$(cast storage "$a" "$IMPL_SLOT" --rpc-url $RPC)
+  [ "$(norm "$got")" = "$(norm "$ex")" ] && pass "$n proxy now points at new impl" || fail "$n impl slot got=$got want=$ex"
+done
+# pre-existing storage intact
+[ "$(cast call $ACCOUNT 'totalScheduledWithdrawals()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$A_TSW" ] && pass "Account.totalScheduledWithdrawals intact ($A_TSW)" || fail "Account.tsw changed"
+[ "$(cast call $ACCOUNT 'manager()(address)' --rpc-url $RPC)" = "$A_MGR" ] && pass "Account.manager intact" || fail "Account.manager changed"
+[ "$(cast call $ACCOUNT 'owner()(address)' --rpc-url $RPC)" = "$A_OWN" ] && pass "Account.owner intact (still MultiSig)" || fail "Account.owner changed"
+[ "$(cast call $DS 'totalStCeloInStrategy()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$DS_TOTAL" ] && pass "DefaultStrategy.totalStCeloInStrategy intact ($DS_TOTAL)" || fail "DS.total changed"
+[ "$(cast call $DS 'maxGroupsToWithdrawFrom()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$DS_MAXW" ] && pass "DefaultStrategy.maxGroupsToWithdrawFrom intact ($DS_MAXW)" || fail "DS.maxW changed"
+[ "$(cast call $SGS 'totalStCeloLocked()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$SGS_LOCKED" ] && pass "SpecificGroupStrategy.totalStCeloLocked intact ($SGS_LOCKED)" || fail "SGS.locked changed"
+# new code live + versions
+cast call $ACCOUNT "getRealisableCeloForGroup(address)(uint256)" 0x81AE1C73A326325216E25ff1af9EA3871195036E --rpc-url $RPC >/dev/null 2>&1 \
+  && pass "Account.getRealisableCeloForGroup live (new code active)" || fail "new Account code not live"
+chk(){ v=$(cast call "$1" "getVersionNumber()(uint256,uint256,uint256,uint256)" --rpc-url $RPC 2>/dev/null|tr '\n' ' '|sed 's/ *$//'); [ "$v" = "$2" ] && pass "$3 version $v" || fail "$3 version got [$v] want [$2]"; }
+chk $ACCOUNT "1 2 1 0" Account
+chk $DS "1 2 0 0" DefaultStrategy
+chk $SGS "1 1 1 0" SpecificGroupStrategy
+chk $MANAGER "1 3 1 0" Manager
+
+echo
+if [ $FAIL -eq 0 ]; then
+  echo "ALL CHECKS PASSED - Celo Governance can release the fix via the MultiSig:"
+  echo "  Governance.execute -> MultiSig.governanceProposeAndExecute -> upgradeTo x4"
+  echo "  storage preserved, new code live. CGP tx in /tmp/stcelo-fix-cgp.json"
+else
+  echo "$FAIL CHECK(S) FAILED"
+fi
+exit $FAIL

--- a/scripts/release-stuck-withdrawal-fix.sh
+++ b/scripts/release-stuck-withdrawal-fix.sh
@@ -82,13 +82,26 @@ fi
 
 # ---------------------------------------------------------------------------
 echo "=== deploying the 4 new implementations ==="
-deploy(){ cast send --rpc-url "$RPC" --private-key "$DEPLOY_KEY" $SEND_EXTRA --create "$1" --json 2>/dev/null | jq -r .contractAddress; }
-A_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Account.sol/Account.json)")
-M_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Manager.sol/Manager.json)")
-S_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/SpecificGroupStrategy.sol/SpecificGroupStrategy.json)")
-LIB=$(deploy "$(jq -r .bytecode artifacts/contracts/common/linkedlists/AddressSortedLinkedList.sol/AddressSortedLinkedList.json)")
-DBC=$(jq -r .bytecode artifacts/contracts/DefaultStrategy.sol/DefaultStrategy.json | sed "s/__\$[0-9a-f]*\$__/$(norm "$LIB")/g")
-D_IMPL=$(deploy "$DBC")
+# Deploy creation bytecode; surface the cast error (and abort) on failure.
+deploy(){
+  local out addr
+  out=$(cast send --rpc-url "$RPC" --private-key "$DEPLOY_KEY" $SEND_EXTRA --create "$1" --json 2>/tmp/deploy-err.log)
+  addr=$(echo "$out" | jq -r '.contractAddress // empty' 2>/dev/null)
+  if [ -z "$addr" ] || [ "$addr" = "null" ]; then
+    echo "DEPLOY FAILED:" >&2; tail -5 /tmp/deploy-err.log >&2; return 1
+  fi
+  echo "$addr"
+}
+A_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Account.sol/Account.json)") || exit 1
+M_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Manager.sol/Manager.json)") || exit 1
+S_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/SpecificGroupStrategy.sol/SpecificGroupStrategy.json)") || exit 1
+LIB=$(deploy "$(jq -r .bytecode artifacts/contracts/common/linkedlists/AddressSortedLinkedList.sol/AddressSortedLinkedList.json)") || exit 1
+# Link DefaultStrategy to the deployed library. The placeholder must be replaced
+# by the full 40-hex address (lowercased, 0x stripped, LEADING ZEROS PRESERVED).
+LIB_HEX=$(echo "${LIB#0x}" | tr 'A-Z' 'a-z')
+DBC=$(jq -r .bytecode artifacts/contracts/DefaultStrategy.sol/DefaultStrategy.json | sed "s/__\$[0-9a-f]*\$__/$LIB_HEX/g")
+case "$DBC" in *'__$'*) echo "ERROR: DefaultStrategy bytecode still has an unlinked library placeholder" >&2; exit 1;; esac
+D_IMPL=$(deploy "$DBC") || exit 1
 for v in "$A_IMPL:Account" "$M_IMPL:Manager" "$S_IMPL:SpecificGroupStrategy" "$D_IMPL:DefaultStrategy" "$LIB:AddressSortedLinkedList"; do
   [ -n "${v%%:*}" ] && [ "${v%%:*}" != null ] || { echo "deploy failed: ${v##*:}"; exit 1; }
   echo "  ${v##*:}: ${v%%:*}"

--- a/scripts/release-stuck-withdrawal-fix.sh
+++ b/scripts/release-stuck-withdrawal-fix.sh
@@ -6,35 +6,39 @@
 # implementations (Account, DefaultStrategy, SpecificGroupStrategy, Manager)
 # via a CELO GOVERNANCE proposal.
 #
-# The stCELO proxies are owned by the stCELO MultiSig, but the MultiSig exposes
+# The proxies are owned by the stCELO MultiSig, which exposes
 # `governanceProposeAndExecute(destinations, values, payloads)` gated by
-# `onlyGovernance` - so Celo Governance can execute a batch of calls through it
-# directly (no owner timelock). The release is therefore a single CGP
-# transaction: Governance -> MultiSig.governanceProposeAndExecute([4 proxies],
-# [0,0,0,0], [upgradeTo(newImpl) x4]).
+# `onlyGovernance`. So Celo Governance executes a single batched call through
+# it - no owner confirmations, no timelock. The release CGP is one tx:
+#   Governance -> MultiSig.governanceProposeAndExecute(
+#       [Account, DefaultStrategy, SpecificGroupStrategy, Manager],
+#       [0,0,0,0],
+#       [upgradeTo(implA), upgradeTo(implDS), upgradeTo(implSGS), upgradeTo(implMgr)])
 #
-# Modes:
-#   (default) FORK TEST - fork mainnet, deploy impls, impersonate Celo
-#             Governance, execute the proposal, and assert upgrades + that
-#             pre-existing storage is intact and new code is live.
-#   --emit-only - deploy impls against the fork (or a node) and print the CGP
-#             transaction (to / value / data) + a celocli-style JSON, without
-#             asserting. Use the deployed impl addresses from a real broadcast
-#             when filing the actual CGP.
+# Usage:
+#   scripts/release-stuck-withdrawal-fix.sh fork        # (default) fork test
+#   scripts/release-stuck-withdrawal-fix.sh mainnet     # real deploy + verify + CGP
 #
-# Requirements: anvil, cast, jq, python3, yarn (foundry in PATH or ~/.foundry/bin).
-# RPC: https://forno.celo.org (override via CELO_RPC_URL).
+# fork    : fork mainnet, deploy ephemeral impls, impersonate Celo Governance,
+#           execute the proposal, assert upgrades + storage intact + new code
+#           live. No explorer verification (fork addresses are throwaway).
+# mainnet : REAL broadcast. Deploys the 4 impls (+ library) to Celo mainnet,
+#           verifies each on Celoscan AND Blockscout, then builds + prints the
+#           CGP transaction/JSON with the real addresses. Does NOT execute the
+#           upgrade - that happens when the CGP passes the Governance vote.
+#           Required env: DEPLOYER_PK, CELO_SCAN_API_KEY.
+#
+# Requirements: anvil, cast, forge, jq, python3, yarn, npx (foundry in PATH).
 set -uo pipefail
 export PATH="$HOME/.foundry/bin:$PATH"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-MODE="${1:-fork-test}"
+TARGET="${1:-fork}"
 RPC_FORK="${CELO_RPC_URL:-https://forno.celo.org}"
-PORT=8591; RPC="http://127.0.0.1:${PORT}"
+PORT=8591; ANVIL_RPC="http://127.0.0.1:${PORT}"
 GAS=25000000000; BIG=0x10000000000000000000000
-# anvil default funded key (deployer in the fork).
-PK=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+ANVIL_PK=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # --- mainnet addresses ---
 REGISTRY=0x000000000000000000000000000000000000ce10
@@ -44,76 +48,96 @@ MANAGER=0x0239b96D10a434a56CC9E09383077A0490cF9398
 DS=0x3A3ed74B1cC543D5EB323f70ac2F19977a0eA088
 SGS=0xb88af6EAc9cd146D8b03b66708EF76beBD937871
 IMPL_SLOT=0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+# verification
+SOLC_VERSION=0.8.11
+EVM_VERSION=istanbul          # optimizer is DISABLED in hardhat.config for 0.8.11
+BLOCKSCOUT_API=https://celo.blockscout.com/api
+DS_LIB_PATH="contracts/common/linkedlists/AddressSortedLinkedList.sol:AddressSortedLinkedList"
 
 FAIL=0; pass(){ echo "  [PASS] $*"; }; fail(){ echo "  [FAIL] $*"; FAIL=$((FAIL+1)); }
 cleanup(){ pkill -f "anvil .*port ${PORT}" 2>/dev/null || true; }
 trap cleanup EXIT
+norm(){ echo "$1" | tr 'A-Z' 'a-z' | sed 's/^0x0*//'; }
 
-start_anvil(){
-  anvil --fork-url "$RPC_FORK" --celo --port "$PORT" --host 127.0.0.1 \
-    --disable-code-size-limit --base-fee "$GAS" --gas-price "$GAS" >/tmp/anvil-release.log 2>&1 &
-  for i in $(seq 1 60); do cast block-number --rpc-url "$RPC" >/dev/null 2>&1 && return 0; sleep 1; done
-  echo "anvil failed to start"; tail -20 /tmp/anvil-release.log; exit 1
-}
-
-deploy(){ cast send --rpc-url "$RPC" --private-key "$PK" --legacy --gas-price "$GAS" --create "$1" --json 2>/dev/null | jq -r .contractAddress; }
-
+# ---------------------------------------------------------------------------
 echo "=== compiling ==="
 yarn --silent compile >/tmp/release-compile.log 2>&1 || { echo "compile failed"; tail /tmp/release-compile.log; exit 1; }
 
-echo "=== starting anvil fork of $RPC_FORK ==="
-start_anvil
-echo "  forked block: $(cast block-number --rpc-url "$RPC")"
+# pick RPC + deployer per target
+if [ "$TARGET" = "fork" ]; then
+  echo "=== starting anvil fork of $RPC_FORK ==="
+  anvil --fork-url "$RPC_FORK" --celo --port "$PORT" --host 127.0.0.1 \
+    --disable-code-size-limit --base-fee "$GAS" --gas-price "$GAS" >/tmp/anvil-release.log 2>&1 &
+  for i in $(seq 1 60); do cast block-number --rpc-url "$ANVIL_RPC" >/dev/null 2>&1 && break; sleep 1; done
+  RPC="$ANVIL_RPC"; DEPLOY_KEY="$ANVIL_PK"; SEND_EXTRA="--legacy --gas-price $GAS"
+  echo "  forked block: $(cast block-number --rpc-url "$RPC")"
+elif [ "$TARGET" = "mainnet" ]; then
+  : "${DEPLOYER_PK:?set DEPLOYER_PK for mainnet deploy}"
+  : "${CELO_SCAN_API_KEY:?set CELO_SCAN_API_KEY for Celoscan verification}"
+  RPC="$RPC_FORK"; DEPLOY_KEY="$DEPLOYER_PK"; SEND_EXTRA="--legacy"
+  echo "=== MAINNET broadcast via $RPC (deployer $(cast wallet address --private-key "$DEPLOY_KEY")) ==="
+else
+  echo "unknown target '$TARGET' (use: fork | mainnet)"; exit 1
+fi
 
+# ---------------------------------------------------------------------------
 echo "=== deploying the 4 new implementations ==="
+deploy(){ cast send --rpc-url "$RPC" --private-key "$DEPLOY_KEY" $SEND_EXTRA --create "$1" --json 2>/dev/null | jq -r .contractAddress; }
 A_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Account.sol/Account.json)")
 M_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/Manager.sol/Manager.json)")
 S_IMPL=$(deploy "$(jq -r .bytecode artifacts/contracts/SpecificGroupStrategy.sol/SpecificGroupStrategy.json)")
 LIB=$(deploy "$(jq -r .bytecode artifacts/contracts/common/linkedlists/AddressSortedLinkedList.sol/AddressSortedLinkedList.json)")
-DBC=$(jq -r .bytecode artifacts/contracts/DefaultStrategy.sol/DefaultStrategy.json | sed "s/__\$[0-9a-f]*\$__/$(echo "${LIB#0x}" | tr 'A-Z' 'a-z')/g")
+DBC=$(jq -r .bytecode artifacts/contracts/DefaultStrategy.sol/DefaultStrategy.json | sed "s/__\$[0-9a-f]*\$__/$(norm "$LIB")/g")
 D_IMPL=$(deploy "$DBC")
-for v in "$A_IMPL:Account" "$M_IMPL:Manager" "$S_IMPL:SpecificGroupStrategy" "$D_IMPL:DefaultStrategy"; do
+for v in "$A_IMPL:Account" "$M_IMPL:Manager" "$S_IMPL:SpecificGroupStrategy" "$D_IMPL:DefaultStrategy" "$LIB:AddressSortedLinkedList"; do
   [ -n "${v%%:*}" ] && [ "${v%%:*}" != null ] || { echo "deploy failed: ${v##*:}"; exit 1; }
-  echo "  ${v##*:} impl: ${v%%:*}"
+  echo "  ${v##*:}: ${v%%:*}"
 done
-echo "  (DefaultStrategy linked to AddressSortedLinkedList $LIB)"
 
+# ---------------------------------------------------------------------------
 echo "=== building the governance proposal calldata ==="
-# Per-proxy upgradeTo(newImpl) payloads.
 P_ACC=$(cast calldata "upgradeTo(address)" "$A_IMPL")
 P_MGR=$(cast calldata "upgradeTo(address)" "$M_IMPL")
 P_SGS=$(cast calldata "upgradeTo(address)" "$S_IMPL")
 P_DS=$(cast calldata "upgradeTo(address)" "$D_IMPL")
-# The single CGP transaction: Governance -> MultiSig.governanceProposeAndExecute(...).
-DESTS="[$ACCOUNT,$DS,$SGS,$MANAGER]"
-VALUES="[0,0,0,0]"
-PAYLOADS="[$P_ACC,$P_DS,$P_SGS,$P_MGR]"
+DESTS="[$ACCOUNT,$DS,$SGS,$MANAGER]"; VALUES="[0,0,0,0]"; PAYLOADS="[$P_ACC,$P_DS,$P_SGS,$P_MGR]"
 GPE=$(cast calldata "governanceProposeAndExecute(address[],uint256[],bytes[])" "$DESTS" "$VALUES" "$PAYLOADS")
-echo "  CGP transaction:"
-echo "    to:    $MULTISIG"
-echo "    value: 0"
-echo "    data:  ${GPE:0:74}... (${#GPE} chars)"
-# celocli-style proposal JSON (raw form).
-PROPOSAL_JSON=$(cat <<JSON
-[
-  { "value": "0", "to": "$MULTISIG", "data": "$GPE" }
-]
-JSON
-)
-echo "$PROPOSAL_JSON" > /tmp/stcelo-fix-cgp.json
-echo "  wrote CGP JSON -> /tmp/stcelo-fix-cgp.json"
+printf '[\n  { "value": "0", "to": "%s", "data": "%s" }\n]\n' "$MULTISIG" "$GPE" > /tmp/stcelo-fix-cgp.json
+echo "  CGP tx -> to=$MULTISIG value=0 data=${GPE:0:50}... (${#GPE} chars)"
+echo "  CGP JSON -> /tmp/stcelo-fix-cgp.json"
 
-if [ "$MODE" = "--emit-only" ]; then
-  echo; echo "emit-only mode: proposal built, not executed."
-  echo "NOTE: deploy the impls on mainnet (real broadcast) and substitute their"
-  echo "      addresses before filing the CGP."
+# ---------------------------------------------------------------------------
+if [ "$TARGET" = "mainnet" ]; then
+  echo "=== verifying implementations on Celoscan + Blockscout ==="
+  printf 'module.exports = { "%s": "%s" };\n' "AddressSortedLinkedList" "$LIB" > /tmp/ds-libs.js
+  verify_celoscan(){ # <addr> [extra hardhat args...]
+    local a="$1"; shift
+    echo "  [Celoscan] $a"; npx hardhat verify --network celo "$a" "$@" 2>&1 | tail -3 || true; }
+  verify_blockscout(){ # <addr> <path:Contract> [extra forge args...]
+    local a="$1" cp="$2"; shift 2
+    echo "  [Blockscout] $a ($cp)"; forge verify-contract "$a" "$cp" \
+      --verifier blockscout --verifier-url "$BLOCKSCOUT_API" \
+      --compiler-version "$SOLC_VERSION" --evm-version "$EVM_VERSION" --watch "$@" 2>&1 | tail -3 || true; }
+
+  verify_celoscan  "$LIB";    verify_blockscout "$LIB"    "$DS_LIB_PATH"
+  verify_celoscan  "$A_IMPL"; verify_blockscout "$A_IMPL" "contracts/Account.sol:Account"
+  verify_celoscan  "$M_IMPL"; verify_blockscout "$M_IMPL" "contracts/Manager.sol:Manager"
+  verify_celoscan  "$S_IMPL"; verify_blockscout "$S_IMPL" "contracts/SpecificGroupStrategy.sol:SpecificGroupStrategy"
+  verify_celoscan  "$D_IMPL" --libraries /tmp/ds-libs.js
+  verify_blockscout "$D_IMPL" "contracts/DefaultStrategy.sol:DefaultStrategy" --libraries "$DS_LIB_PATH:$LIB"
+
+  echo
+  echo "MAINNET deploy + verification submitted. NEXT: file the CGP from"
+  echo "/tmp/stcelo-fix-cgp.json (Governance -> MultiSig.governanceProposeAndExecute)."
+  echo "The upgrade executes only after the proposal passes the Governance vote."
   exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# fork target: execute the proposal as Celo Governance and assert outcome.
 echo "=== FORK TEST: execute the proposal as Celo Governance ==="
 GOV=$(cast call "$REGISTRY" "getAddressForStringOrDie(string)(address)" "Governance" --rpc-url "$RPC")
 echo "  Celo Governance: $GOV"
-# snapshot pre-existing storage
 A_TSW=$(cast call $ACCOUNT "totalScheduledWithdrawals()(uint256)" --rpc-url $RPC | awk '{print $1}')
 A_MGR=$(cast call $ACCOUNT "manager()(address)" --rpc-url $RPC)
 A_OWN=$(cast call $ACCOUNT "owner()(address)" --rpc-url $RPC)
@@ -126,37 +150,24 @@ cast rpc --rpc-url $RPC anvil_setBalance "$GOV" "$BIG" >/dev/null
 ST=$(cast send --rpc-url $RPC --from "$GOV" --unlocked --legacy --gas-price $GAS \
   "$MULTISIG" "governanceProposeAndExecute(address[],uint256[],bytes[])" "$DESTS" "$VALUES" "$PAYLOADS" \
   --json 2>/dev/null | jq -r '.status')
-[ "$ST" = "0x1" ] && pass "governanceProposeAndExecute succeeded (Governance executed the batch)" || fail "governance execute tx status=$ST"
+[ "$ST" = "0x1" ] && pass "governanceProposeAndExecute succeeded" || fail "governance execute tx status=$ST"
 
-# impl slots updated
-norm(){ echo "$1" | tr 'A-Z' 'a-z' | sed 's/^0x0*//'; }
 for pair in "Account:$ACCOUNT:$A_IMPL" "Manager:$MANAGER:$M_IMPL" "SGS:$SGS:$S_IMPL" "DefaultStrategy:$DS:$D_IMPL"; do
   n=$(echo "$pair"|cut -d: -f1); a=$(echo "$pair"|cut -d: -f2); ex=$(echo "$pair"|cut -d: -f3)
   got=$(cast storage "$a" "$IMPL_SLOT" --rpc-url $RPC)
   [ "$(norm "$got")" = "$(norm "$ex")" ] && pass "$n proxy now points at new impl" || fail "$n impl slot got=$got want=$ex"
 done
-# pre-existing storage intact
 [ "$(cast call $ACCOUNT 'totalScheduledWithdrawals()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$A_TSW" ] && pass "Account.totalScheduledWithdrawals intact ($A_TSW)" || fail "Account.tsw changed"
 [ "$(cast call $ACCOUNT 'manager()(address)' --rpc-url $RPC)" = "$A_MGR" ] && pass "Account.manager intact" || fail "Account.manager changed"
 [ "$(cast call $ACCOUNT 'owner()(address)' --rpc-url $RPC)" = "$A_OWN" ] && pass "Account.owner intact (still MultiSig)" || fail "Account.owner changed"
 [ "$(cast call $DS 'totalStCeloInStrategy()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$DS_TOTAL" ] && pass "DefaultStrategy.totalStCeloInStrategy intact ($DS_TOTAL)" || fail "DS.total changed"
 [ "$(cast call $DS 'maxGroupsToWithdrawFrom()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$DS_MAXW" ] && pass "DefaultStrategy.maxGroupsToWithdrawFrom intact ($DS_MAXW)" || fail "DS.maxW changed"
 [ "$(cast call $SGS 'totalStCeloLocked()(uint256)' --rpc-url $RPC|awk '{print $1}')" = "$SGS_LOCKED" ] && pass "SpecificGroupStrategy.totalStCeloLocked intact ($SGS_LOCKED)" || fail "SGS.locked changed"
-# new code live + versions
 cast call $ACCOUNT "getRealisableCeloForGroup(address)(uint256)" 0x81AE1C73A326325216E25ff1af9EA3871195036E --rpc-url $RPC >/dev/null 2>&1 \
   && pass "Account.getRealisableCeloForGroup live (new code active)" || fail "new Account code not live"
 chk(){ v=$(cast call "$1" "getVersionNumber()(uint256,uint256,uint256,uint256)" --rpc-url $RPC 2>/dev/null|tr '\n' ' '|sed 's/ *$//'); [ "$v" = "$2" ] && pass "$3 version $v" || fail "$3 version got [$v] want [$2]"; }
-chk $ACCOUNT "1 2 1 0" Account
-chk $DS "1 2 0 0" DefaultStrategy
-chk $SGS "1 1 1 0" SpecificGroupStrategy
-chk $MANAGER "1 3 1 0" Manager
+chk $ACCOUNT "1 2 1 0" Account; chk $DS "1 2 0 0" DefaultStrategy; chk $SGS "1 1 1 0" SpecificGroupStrategy; chk $MANAGER "1 3 1 0" Manager
 
 echo
-if [ $FAIL -eq 0 ]; then
-  echo "ALL CHECKS PASSED - Celo Governance can release the fix via the MultiSig:"
-  echo "  Governance.execute -> MultiSig.governanceProposeAndExecute -> upgradeTo x4"
-  echo "  storage preserved, new code live. CGP tx in /tmp/stcelo-fix-cgp.json"
-else
-  echo "$FAIL CHECK(S) FAILED"
-fi
+[ $FAIL -eq 0 ] && echo "ALL CHECKS PASSED - Governance release via MultiSig.governanceProposeAndExecute works; storage preserved, new code live. CGP in /tmp/stcelo-fix-cgp.json" || echo "$FAIL CHECK(S) FAILED"
 exit $FAIL

--- a/scripts/verify-stuck-withdrawal-mainnet-fork.sh
+++ b/scripts/verify-stuck-withdrawal-mainnet-fork.sh
@@ -1,0 +1,517 @@
+#!/usr/bin/env bash
+#
+# verify-stuck-withdrawal-mainnet-fork.sh
+# =======================================
+# Proves the staked-CELO stuck-withdrawal fix against REAL Celo mainnet state
+# on anvil forks. Runs two scenarios and prints explicit [PASS]/[FAIL] per
+# assertion. Exits non-zero if any assertion fails.
+#
+#   SCENARIO A  - RECOVERY: recreate the stuck pin at the withdrawal block by
+#                 replaying the user's Manager.withdraw with the DEPLOYED code,
+#                 then the patched permissionless `rescueScheduledWithdrawal`
+#                 moves the pin off the bad group onto healthy groups and a
+#                 real `Account.withdraw` succeeds. (The live mainnet pin
+#                 self-resolved post-incident, so recovery is demonstrated on a
+#                 reproduced pin rather than mutable current state.)
+#
+#   SCENARIO B1 - REPRODUCE the bug with the DEPLOYED code at the exact
+#                 withdrawal-initiation block (67413681): Manager.withdraw
+#                 pins an unfulfillable amount to the bad group -> user stuck.
+#
+#   SCENARIO B2 - PREVENTION with the patched code (all four impls upgraded)
+#                 at the same block: Manager.withdraw either reverts (user
+#                 keeps stCELO) OR succeeds with every pinned group's pin
+#                 physically fulfillable, and a real Account.withdraw works.
+#
+# Requirements: anvil, cast, forge, jq, python3, yarn (in PATH or ~/.foundry/bin).
+# RPC: https://forno.celo.org (override via CELO_RPC_URL).
+#
+# Usage:  scripts/verify-stuck-withdrawal-mainnet-fork.sh
+#
+set -uo pipefail
+
+# --------------------------------------------------------------------------
+# Environment / tooling
+# --------------------------------------------------------------------------
+export PATH="$HOME/.foundry/bin:$PATH"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RPC_FORK=${CELO_RPC_URL:-https://forno.celo.org}
+
+# Distinct ports per scenario so concurrent leftovers cannot collide.
+PORT_A=8561
+PORT_B1=8562
+PORT_B2=8563
+RPC_A="http://127.0.0.1:${PORT_A}"
+RPC_B1="http://127.0.0.1:${PORT_B1}"
+RPC_B2="http://127.0.0.1:${PORT_B2}"
+
+# Fixed gas pricing. REQUIRED for forks pinned to a historical block: anvil's
+# Celo block production calls eth_feeHistory / exchange-rate lookups against
+# the remote node, and the public Forno archive prunes that historical state,
+# making block mining fail with "failed to get exchange rates". Pinning the
+# base fee / gas price and sending --legacy txs avoids those remote lookups.
+GAS_PRICE=25000000000          # 25 gwei
+BIG_BAL=0x10000000000000000000000
+
+# anvil default funded signer (random permissionless EOA).
+RANDOM_EOA=0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266
+RANDOM_PK=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+# --------------------------------------------------------------------------
+# Verified mainnet addresses / facts
+# --------------------------------------------------------------------------
+ACCOUNT_PROXY=0x4aAD04D41FD7fd495503731C5a2579e19054C432
+MANAGER_PROXY=0x0239b96D10a434a56CC9E09383077A0490cF9398
+DS_PROXY=0x3A3ed74B1cC543D5EB323f70ac2F19977a0eA088
+SGS_PROXY=0xb88af6EAc9cd146D8b03b66708EF76beBD937871
+MULTISIG=0x78DaA21FcE4D30E74fF745Da3204764a0ad40179
+ELECTION=0x8D6677192144292870907E3Fa8A5527fE55A7ff6
+STCELO=0xC668583dcbDc9ae6FA3CE46462758188adfdfC24
+
+STUCK_USER=0x85ca0Dff027102ea3FBF1c077524eab21D1F7927
+BAD_GROUP=0x81AE1C73A326325216E25ff1af9EA3871195036E
+WITHDRAW_BLOCK=67413681
+STCELO_AMOUNT=146388633198899438192672
+
+# Candidate healthy groups (re-verified on the fork before use).
+HEALTHY_CANDIDATES=(
+  0xc8A81D473992c7c6D3F469A8263F24914625709d
+  0xD72Ed2e3db984bAC3bB351FE652200dE527eFfcf
+  0xc24baeac0Fd189637112B7e33d22FfF2730aF993
+)
+
+ZERO=0x0000000000000000000000000000000000000000
+
+# --------------------------------------------------------------------------
+# Result tracking + helpers
+# --------------------------------------------------------------------------
+FAILURES=0
+pass() { echo "  [PASS] $*"; }
+fail() { echo "  [FAIL] $*"; FAILURES=$((FAILURES + 1)); }
+section() { echo; echo "============================================================"; echo "$*"; echo "============================================================"; }
+
+# assert_ge LABEL A B  -> pass iff A >= B (big-int safe)
+assert_ge() {
+  local label="$1" a="$2" b="$3"
+  if python3 -c "import sys; sys.exit(0 if int('$a') >= int('$b') else 1)"; then
+    pass "$label ($a >= $b)"
+  else
+    fail "$label ($a < $b)"
+  fi
+}
+# assert_lt LABEL A B  -> pass iff A < B
+assert_lt() {
+  local label="$1" a="$2" b="$3"
+  if python3 -c "import sys; sys.exit(0 if int('$a') < int('$b') else 1)"; then
+    pass "$label ($a < $b)"
+  else
+    fail "$label ($a >= $b)"
+  fi
+}
+# assert_eq LABEL A B
+assert_eq() {
+  local label="$1" a="$2" b="$3"
+  if python3 -c "import sys; sys.exit(0 if int('$a') == int('$b') else 1)"; then
+    pass "$label (= $a)"
+  else
+    fail "$label (got $a, want $b)"
+  fi
+}
+
+# cast call with small retry to tolerate Forno rate limiting.
+ccall() {
+  local rpc="$1"; shift
+  local out i
+  for i in 1 2 3 4 5; do
+    if out=$(cast call --rpc-url "$rpc" "$@" 2>/dev/null); then
+      echo "$out" | awk '{print $1}'
+      return 0
+    fi
+    sleep 1
+  done
+  echo "0"
+  return 1
+}
+
+# Read a uint return, first whitespace token only.
+pin_of() { ccall "$1" "$2" "scheduledWithdrawalsForGroupAndBeneficiary(address,address)(uint256)" "$3" "$4"; }
+realisable_of() { ccall "$1" "$2" "getRealisableCeloForGroup(address)(uint256)" "$3"; }
+revokable_of() { ccall "$1" "$ELECTION" "getTotalVotesForGroupByAccount(address,address)(uint256)" "$2" "$ACCOUNT_PROXY"; }
+
+# Start anvil. start_anvil PORT LOGFILE [BLOCK]
+start_anvil() {
+  local port="$1" log="$2" block="${3:-}"
+  local args=(--fork-url "$RPC_FORK" --celo --port "$port" --host 127.0.0.1
+              --disable-code-size-limit --base-fee "$GAS_PRICE" --gas-price "$GAS_PRICE")
+  if [ -n "$block" ]; then
+    args+=(--fork-block-number "$block")
+  fi
+  anvil "${args[@]}" > "$log" 2>&1 &
+  local rpc="http://127.0.0.1:${port}"
+  local i
+  for i in $(seq 1 60); do
+    if cast block-number --rpc-url "$rpc" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: anvil on port $port never became ready; see $log" >&2
+  tail -20 "$log" >&2
+  return 1
+}
+
+cleanup() {
+  pkill -f "anvil .*port ${PORT_A}" 2>/dev/null || true
+  pkill -f "anvil .*port ${PORT_B1}" 2>/dev/null || true
+  pkill -f "anvil .*port ${PORT_B2}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# send_tx RPC FROM_SPEC TO SIG [ARGS...]   FROM_SPEC = "pk:<key>" or "from:<addr>"
+# Echoes normalised receipt status: "1" (success), "0" (revert), "" (RPC error).
+send_tx() {
+  local rpc="$1" from="$2" to="$3" sig="$4"; shift 4
+  local base=(send --rpc-url "$rpc" --legacy --gas-price "$GAS_PRICE" --gas-limit 12000000)
+  if [[ "$from" == pk:* ]]; then
+    base+=(--private-key "${from#pk:}")
+  else
+    base+=(--from "${from#from:}" --unlocked)
+  fi
+  local raw
+  raw=$(cast "${base[@]}" "$to" "$sig" "$@" --json 2>/dev/null | jq -r '.status // empty' 2>/dev/null)
+  case "$raw" in
+    0x1|1) echo "1" ;;
+    0x0|0) echo "0" ;;
+    *)     echo "" ;;
+  esac
+}
+
+# Deploy + upgrade one UUPS proxy. Handles library-linked DefaultStrategy.
+# deploy_and_upgrade RPC CONTRACT PROXY [LIB_ADDR]
+deploy_and_upgrade() {
+  local rpc="$1" contract="$2" proxy="$3" lib="${4:-}"
+  local bc impl
+  bc=$(jq -r '.bytecode' "artifacts/contracts/${contract}.sol/${contract}.json")
+  if echo "$bc" | grep -q '__\$'; then
+    if [ -z "$lib" ]; then
+      echo "ERROR: $contract needs a library but none supplied" >&2
+      return 1
+    fi
+    local libnoaddr
+    libnoaddr=$(echo "$lib" | sed 's/^0x//' | tr 'A-Z' 'a-z')
+    # Replace any link placeholder __$...$__ with the library address.
+    bc=$(echo "$bc" | sed "s/__\$[0-9a-f]*\$__/$libnoaddr/g")
+  fi
+  impl=$(cast send --rpc-url "$rpc" --private-key "$RANDOM_PK" --legacy \
+          --gas-price "$GAS_PRICE" --create "$bc" --json 2>/dev/null | jq -r .contractAddress)
+  if [ -z "$impl" ] || [ "$impl" = "null" ]; then
+    echo "ERROR: failed to deploy $contract" >&2
+    return 1
+  fi
+  cast send --rpc-url "$rpc" --from "$MULTISIG" --unlocked --legacy \
+    --gas-price "$GAS_PRICE" "$proxy" "upgradeTo(address)" "$impl" >/dev/null 2>&1
+  echo "$impl"
+}
+
+deploy_library() {
+  local rpc="$1"
+  local bc
+  bc=$(jq -r '.bytecode' artifacts/contracts/common/linkedlists/AddressSortedLinkedList.sol/AddressSortedLinkedList.json)
+  cast send --rpc-url "$rpc" --private-key "$RANDOM_PK" --legacy \
+    --gas-price "$GAS_PRICE" --create "$bc" --json 2>/dev/null | jq -r .contractAddress
+}
+
+impersonate() {
+  local rpc="$1" addr="$2"
+  cast rpc --rpc-url "$rpc" anvil_impersonateAccount "$addr" >/dev/null 2>&1
+  cast rpc --rpc-url "$rpc" anvil_setBalance "$addr" "$BIG_BAL" >/dev/null 2>&1
+}
+
+# Find the index of `group` in Account's voted-for groups list (for Account.withdraw).
+group_index() {
+  local rpc="$1" group="$2"
+  cast call "$ELECTION" "getGroupsVotedForByAccount(address)(address[])" "$ACCOUNT_PROXY" --rpc-url "$rpc" 2>/dev/null \
+    | grep -ioE '0x[0-9a-fA-F]{40}' | nl -v0 \
+    | grep -i "${group#0x}" | awk '{print $1}' | head -1
+}
+
+# Compute Election lesser/greater for revoking `amount` from `group`.
+# Echoes "<lesser> <greater>".
+lesser_greater() {
+  local rpc="$1" group="$2" amount="$3"
+  local gtotal new lg
+  gtotal=$(ccall "$rpc" "$ELECTION" "getTotalVotesForGroup(address)(uint256)" "$group")
+  new=$(python3 -c "print(max(0, int('$gtotal') - int('$amount')))")
+  cast call "$ELECTION" "getTotalVotesForEligibleValidatorGroups()(address[],uint256[])" \
+    --rpc-url "$rpc" > /tmp/eligible-$$.txt 2>/dev/null
+  lg=$(python3 "$REPO_ROOT/scripts/_lesser_greater.py" "/tmp/eligible-$$.txt" "$group" "$new")
+  rm -f "/tmp/eligible-$$.txt"
+  # _lesser_greater prints "<greater> <lesser>"; re-order to "<lesser> <greater>".
+  local greater lesser
+  greater=$(echo "$lg" | awk '{print $1}')
+  lesser=$(echo "$lg" | awk '{print $2}')
+  echo "$lesser $greater"
+}
+
+# Attempt a real Account.withdraw for `group`. Echoes "0x1"/"0x0"/"".
+attempt_account_withdraw() {
+  local rpc="$1" group="$2"
+  local pin idx lg lesser greater
+  pin=$(pin_of "$rpc" "$ACCOUNT_PROXY" "$group" "$STUCK_USER")
+  idx=$(group_index "$rpc" "$group")
+  [ -z "$idx" ] && { echo ""; return; }
+  lg=$(lesser_greater "$rpc" "$group" "$pin")
+  lesser=$(echo "$lg" | awk '{print $1}')
+  greater=$(echo "$lg" | awk '{print $2}')
+  send_tx "$rpc" "pk:$RANDOM_PK" "$ACCOUNT_PROXY" \
+    "withdraw(address,address,address,address,address,address,uint256)" \
+    "$STUCK_USER" "$group" "$lesser" "$greater" "$lesser" "$greater" "$idx"
+}
+
+# --------------------------------------------------------------------------
+# Compile patched contracts (idempotent).
+# --------------------------------------------------------------------------
+section "Compiling patched contracts (yarn compile)"
+if yarn --silent compile > /tmp/swv-compile.log 2>&1; then
+  echo "  compile OK"
+else
+  echo "  compile FAILED - see /tmp/swv-compile.log"; tail -10 /tmp/swv-compile.log
+  exit 1
+fi
+
+# ==========================================================================
+# SCENARIO A - RECOVERY on the current real stuck state (fork LATEST)
+# ==========================================================================
+section "SCENARIO A - RECOVERY: recreate the stuck pin, then rescue it (fork block $WITHDRAW_BLOCK)"
+start_anvil "$PORT_A" /tmp/swv-anvil-a.log "$WITHDRAW_BLOCK" || exit 1
+echo "  forked block: $(cast block-number --rpc-url "$RPC_A")"
+
+# A.0 recreate the stuck state deterministically. The live mainnet pin
+# self-resolved after the incident (the stale toVote eventually became
+# revokable and the pin was withdrawn), so instead of depending on mutable
+# current state we replay the user's exact Manager.withdraw with the DEPLOYED
+# (buggy) code at the withdrawal-initiation block - the same call that created
+# the real stuck pin (see Scenario B1).
+impersonate "$RPC_A" "$STUCK_USER"
+WST0=$(send_tx "$RPC_A" "from:$STUCK_USER" "$MANAGER_PROXY" "withdraw(uint256)" "$STCELO_AMOUNT")
+echo "  replayed deployed Manager.withdraw(user): status ${WST0:-?}"
+
+# A.1 prove the stuck pin now exists on the bad group
+PIN_A=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$BAD_GROUP" "$STUCK_USER")
+echo "  pin(badGroup,user) = $PIN_A"
+assert_lt "A.1 stuck pin is non-zero" 0 "$PIN_A"
+
+# A.2 upgrade patched Account, prove deficit
+echo "  deploying + upgrading patched Account ..."
+impersonate "$RPC_A" "$MULTISIG"
+NEW_ACC=$(deploy_and_upgrade "$RPC_A" Account "$ACCOUNT_PROXY")
+echo "  new Account impl: $NEW_ACC"
+REAL_BAD_A=$(realisable_of "$RPC_A" "$ACCOUNT_PROXY" "$BAD_GROUP")
+echo "  realisable(badGroup) = $REAL_BAD_A"
+assert_lt "A.2 badGroup realisable < pin (deficit -> stuck)" "$REAL_BAD_A" "$PIN_A"
+
+# A.3 pick 3 healthy groups whose realisable >= their slice
+SLICE=$(python3 -c "print(int('$PIN_A')//3)")
+LAST=$(python3 -c "print(int('$PIN_A') - 2*(int('$PIN_A')//3))")
+echo "  slice=$SLICE last=$LAST"
+G1=${HEALTHY_CANDIDATES[0]}; G2=${HEALTHY_CANDIDATES[1]}; G3=${HEALTHY_CANDIDATES[2]}
+R1=$(realisable_of "$RPC_A" "$ACCOUNT_PROXY" "$G1")
+R2=$(realisable_of "$RPC_A" "$ACCOUNT_PROXY" "$G2")
+R3=$(realisable_of "$RPC_A" "$ACCOUNT_PROXY" "$G3")
+echo "  realisable: $G1=$R1  $G2=$R2  $G3=$R3"
+assert_ge "A.3 G1 realisable >= slice" "$R1" "$SLICE"
+assert_ge "A.3 G2 realisable >= slice" "$R2" "$SLICE"
+assert_ge "A.3 G3 realisable >= last"  "$R3" "$LAST"
+
+# Pre-rescue baselines: the deployed replay may already have pinned the
+# ~claimable remainder of the withdrawal to a healthy group, so assert the
+# rescue adds exactly the slice (delta), not the absolute pin.
+P1_BEFORE=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$G1" "$STUCK_USER")
+P2_BEFORE=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$G2" "$STUCK_USER")
+P3_BEFORE=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$G3" "$STUCK_USER")
+
+# A.4 permissionless rescue from a random EOA
+echo "  calling rescueScheduledWithdrawal from random EOA $RANDOM_EOA ..."
+ST=$(send_tx "$RPC_A" "pk:$RANDOM_PK" "$ACCOUNT_PROXY" \
+  "rescueScheduledWithdrawal(address,address,address[],uint256[])" \
+  "$STUCK_USER" "$BAD_GROUP" "[$G1,$G2,$G3]" "[$SLICE,$SLICE,$LAST]")
+assert_eq "A.4 rescue tx succeeded" "${ST:-0}" "1"
+
+# A.5 pins moved
+PIN_BAD_AFTER=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$BAD_GROUP" "$STUCK_USER")
+assert_eq "A.5 badGroup pin cleared to 0" "$PIN_BAD_AFTER" "0"
+P1=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$G1" "$STUCK_USER")
+P2=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$G2" "$STUCK_USER")
+P3=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$G3" "$STUCK_USER")
+D1=$(python3 -c "print(int('$P1') - int('$P1_BEFORE'))")
+D2=$(python3 -c "print(int('$P2') - int('$P2_BEFORE'))")
+D3=$(python3 -c "print(int('$P3') - int('$P3_BEFORE'))")
+assert_eq "A.5 G1 pin gained slice" "$D1" "$SLICE"
+assert_eq "A.5 G2 pin gained slice" "$D2" "$SLICE"
+assert_eq "A.5 G3 pin gained last"  "$D3" "$LAST"
+
+# A.6 real Account.withdraw on a healthy group must succeed
+echo "  attempting real Account.withdraw on healthy group $G1 ..."
+WST=$(attempt_account_withdraw "$RPC_A" "$G1")
+if [ "${WST:-0}" = "1" ]; then
+  PIN_G1_AFTER=$(pin_of "$RPC_A" "$ACCOUNT_PROXY" "$G1" "$STUCK_USER")
+  pass "A.6 real Account.withdraw(G1) SUCCEEDED (status 1)"
+  assert_eq "A.6 G1 pin cleared after withdraw" "$PIN_G1_AFTER" "0"
+  echo "       -> the previously-stuck user can now withdraw on current state"
+else
+  # Fallback: the guaranteed property is physical fulfillability.
+  fail "A.6 real Account.withdraw(G1) did not return status 1 (got '${WST}')"
+  echo "       guaranteed property still holds: realisable(G1)=$R1 >= slice=$SLICE"
+fi
+
+cleanup; sleep 1
+
+# ==========================================================================
+# SCENARIO B1 - REPRODUCE the bug with DEPLOYED code at block 67413681
+# ==========================================================================
+section "SCENARIO B1 - REPRODUCE stuck withdrawal with DEPLOYED code (block $WITHDRAW_BLOCK)"
+start_anvil "$PORT_B1" /tmp/swv-anvil-b1.log "$WITHDRAW_BLOCK" || exit 1
+echo "  forked block: $(cast block-number --rpc-url "$RPC_B1")"
+
+BAL_PRE=$(ccall "$RPC_B1" "$STCELO" "balanceOf(address)(uint256)" "$STUCK_USER")
+PIN_PRE=$(pin_of "$RPC_B1" "$ACCOUNT_PROXY" "$BAD_GROUP" "$STUCK_USER")
+assert_eq "B1.1 user stCELO balance == withdrawal amount" "$BAL_PRE" "$STCELO_AMOUNT"
+assert_eq "B1.1 badGroup pin == 0 pre-withdrawal" "$PIN_PRE" "0"
+
+echo "  impersonating user and calling Manager.withdraw($STCELO_AMOUNT) on DEPLOYED code ..."
+impersonate "$RPC_B1" "$STUCK_USER"
+ST_B1=$(send_tx "$RPC_B1" "from:$STUCK_USER" "$MANAGER_PROXY" "withdraw(uint256)" "$STCELO_AMOUNT")
+assert_eq "B1.2 Manager.withdraw succeeded (state committed)" "${ST_B1:-0}" "1"
+
+PIN_POST=$(pin_of "$RPC_B1" "$ACCOUNT_PROXY" "$BAD_GROUP" "$STUCK_USER")
+BAL_POST=$(ccall "$RPC_B1" "$STCELO" "balanceOf(address)(uint256)" "$STUCK_USER")
+REVOKABLE_BAD=$(revokable_of "$RPC_B1" "$BAD_GROUP")
+echo "  pin(badGroup,user) post = $PIN_POST"
+echo "  user stCELO post        = $BAL_POST  (burned: stake committed)"
+echo "  Election revokable(bad) = $REVOKABLE_BAD"
+assert_lt "B1.3 deployed code pinned to badGroup (pin > 0)" 0 "$PIN_POST"
+assert_eq "B1.3 user stCELO burned to 0 (cannot undo)" "$BAL_POST" "0"
+assert_lt "B1.3 Election revokable(bad) < pin -> pin UNFULFILLABLE (stuck)" "$REVOKABLE_BAD" "$PIN_POST"
+
+cleanup; sleep 1
+
+# ==========================================================================
+# SCENARIO B2 - PREVENTION with patched code (all 4 impls) at block 67413681
+# ==========================================================================
+section "SCENARIO B2 - PREVENTION with PATCHED code, all 4 impls (block $WITHDRAW_BLOCK)"
+start_anvil "$PORT_B2" /tmp/swv-anvil-b2.log "$WITHDRAW_BLOCK" || exit 1
+echo "  forked block: $(cast block-number --rpc-url "$RPC_B2")"
+
+impersonate "$RPC_B2" "$MULTISIG"
+echo "  deploying AddressSortedLinkedList library ..."
+LIB=$(deploy_library "$RPC_B2")
+echo "  library: $LIB"
+echo "  deploying + upgrading all 4 patched impls via multisig ..."
+I_ACC=$(deploy_and_upgrade "$RPC_B2" Account "$ACCOUNT_PROXY")
+I_MGR=$(deploy_and_upgrade "$RPC_B2" Manager "$MANAGER_PROXY")
+I_DS=$(deploy_and_upgrade "$RPC_B2" DefaultStrategy "$DS_PROXY" "$LIB")
+I_SGS=$(deploy_and_upgrade "$RPC_B2" SpecificGroupStrategy "$SGS_PROXY")
+echo "  Account=$I_ACC"
+echo "  Manager=$I_MGR"
+echo "  DefaultStrategy=$I_DS"
+echo "  SpecificGroupStrategy=$I_SGS"
+if [ -n "$I_ACC" ] && [ -n "$I_MGR" ] && [ -n "$I_DS" ] && [ -n "$I_SGS" ]; then
+  pass "B2.0 all four patched impls deployed + upgraded"
+else
+  fail "B2.0 one or more impls failed to deploy/upgrade"
+fi
+
+echo "  impersonating user and calling Manager.withdraw($STCELO_AMOUNT) on PATCHED code ..."
+impersonate "$RPC_B2" "$STUCK_USER"
+ST_B2=$(send_tx "$RPC_B2" "from:$STUCK_USER" "$MANAGER_PROXY" "withdraw(uint256)" "$STCELO_AMOUNT")
+
+if [ "${ST_B2:-0}" != "1" ]; then
+  # Acceptable outcome: revert -> user keeps stCELO, no silent stuck state.
+  BAL_B2=$(ccall "$RPC_B2" "$STCELO" "balanceOf(address)(uint256)" "$STUCK_USER")
+  pass "B2.1 Manager.withdraw REVERTED on patched code (no silent stuck state)"
+  assert_eq "B2.1 user keeps full stCELO after revert" "$BAL_B2" "$STCELO_AMOUNT"
+  echo "       -> patched code refuses to pin an unfulfillable withdrawal"
+else
+  pass "B2.1 Manager.withdraw SUCCEEDED on patched code"
+  # Every pinned group must have realisable >= its pin (fulfillable).
+  echo "  resulting distribution (group / pin / realisable):"
+  cast call "$ELECTION" "getGroupsVotedForByAccount(address)(address[])" "$ACCOUNT_PROXY" \
+    --rpc-url "$RPC_B2" 2>/dev/null | grep -ioE '0x[0-9a-fA-F]{40}' > /tmp/swv-groups-$$.txt
+  ALL_FULFILLABLE=1
+  BAD_PIN_B2=0
+  while read -r G; do
+    [ -z "$G" ] && continue
+    GP=$(pin_of "$RPC_B2" "$ACCOUNT_PROXY" "$G" "$STUCK_USER")
+    [ "$GP" = "0" ] && continue
+    GR=$(realisable_of "$RPC_B2" "$ACCOUNT_PROXY" "$G")
+    # realisable() subtracts this pin's own earmark; the fulfillability check
+    # is whether Election revokable for the group covers the pin.
+    GREV=$(revokable_of "$RPC_B2" "$G")
+    MARK="OK"
+    if ! python3 -c "import sys; sys.exit(0 if int('$GREV') >= int('$GP') else 1)"; then
+      MARK="UNFULFILLABLE"; ALL_FULFILLABLE=0
+    fi
+    echo "       $G  pin=$GP  realisable=$GR  revokable=$GREV  -> $MARK"
+    if [ "$(echo "$G" | tr 'A-Z' 'a-z')" = "$(echo "$BAD_GROUP" | tr 'A-Z' 'a-z')" ]; then
+      BAD_PIN_B2=$GP
+    fi
+  done < /tmp/swv-groups-$$.txt
+  rm -f /tmp/swv-groups-$$.txt
+
+  if [ "$ALL_FULFILLABLE" = "1" ]; then
+    pass "B2.2 every pinned group has Election revokable >= its pin (fulfillable)"
+  else
+    fail "B2.2 at least one pinned group is unfulfillable"
+  fi
+
+  # The bad group must receive either 0 or a fully-fulfillable pin.
+  if [ "$BAD_PIN_B2" = "0" ]; then
+    pass "B2.3 badGroup received 0 pin"
+  else
+    BAD_REV_B2=$(revokable_of "$RPC_B2" "$BAD_GROUP")
+    assert_ge "B2.3 badGroup pin is fulfillable (revokable >= pin)" "$BAD_REV_B2" "$BAD_PIN_B2"
+  fi
+
+  # B2.4 real Account.withdraw on at least one pinned group must succeed.
+  TARGET=""
+  for G in "$BAD_GROUP" "${HEALTHY_CANDIDATES[@]}"; do
+    GP=$(pin_of "$RPC_B2" "$ACCOUNT_PROXY" "$G" "$STUCK_USER")
+    if [ "$GP" != "0" ]; then TARGET="$G"; break; fi
+  done
+  if [ -n "$TARGET" ]; then
+    echo "  attempting real Account.withdraw on pinned group $TARGET ..."
+    WST2=$(attempt_account_withdraw "$RPC_B2" "$TARGET")
+    if [ "${WST2:-0}" = "1" ]; then
+      PIN_T_AFTER=$(pin_of "$RPC_B2" "$ACCOUNT_PROXY" "$TARGET" "$STUCK_USER")
+      pass "B2.4 real Account.withdraw($TARGET) SUCCEEDED (status 1)"
+      assert_eq "B2.4 target pin cleared after withdraw" "$PIN_T_AFTER" "0"
+    else
+      fail "B2.4 real Account.withdraw($TARGET) did not return status 1 (got '${WST2}')"
+    fi
+  else
+    echo "  (no non-zero pin found to withdraw)"
+  fi
+fi
+
+cleanup
+
+# ==========================================================================
+# Summary
+# ==========================================================================
+section "SUMMARY"
+if [ "$FAILURES" -eq 0 ]; then
+  echo "  ALL ASSERTIONS PASSED"
+  echo
+  echo "  (1) DEPLOYED code at block $WITHDRAW_BLOCK pinned an unfulfillable"
+  echo "      withdrawal to the bad group -> user got stuck (stCELO burned,"
+  echo "      pin > Election revokable)."
+  echo "  (2) PATCHED code prevents the stuck state at the same block."
+  echo "  (3) PATCHED code lets the currently-stuck user be rescued"
+  echo "      permissionlessly and actually withdraw on current mainnet state."
+  exit 0
+else
+  echo "  $FAILURES ASSERTION(S) FAILED"
+  exit 1
+fi

--- a/test-ts/account-realisable.test.ts
+++ b/test-ts/account-realisable.test.ts
@@ -1,0 +1,368 @@
+// Regression tests for the "stuck-withdrawal" root cause:
+//
+// Previously `Account.scheduleWithdrawals` validated capacity via
+// `getCeloForGroup`, which includes `scheduledVotes.toVote` even when that
+// CELO can never be voted (Election cap exhausted by external voters). A
+// withdrawal scheduled against such stale `toVote` could not be revoked, so
+// `Account.withdraw` reverted with `InsufficientRevokableVotes`, pinning the
+// user's CELO to an unfulfillable group.
+//
+// Fix introduces `getRealisableCeloForGroup` (Election active + activatable
+// `toVote` net of earmarked) and switches all withdrawal-capacity checks to
+// it. These tests prove the bug class is dead.
+
+import { ElectionWrapper } from "@celo/contractkit/lib/wrappers/Election";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { default as BigNumberJs } from "bignumber.js";
+import { expect } from "chai";
+import { parseUnits } from "ethers/lib/utils";
+import hre from "hardhat";
+import { Account } from "../typechain-types/Account";
+import { MockRegistry__factory } from "../typechain-types/factories/MockRegistry__factory";
+import {
+  ADDRESS_ZERO,
+  mineToNextEpoch,
+  randomSigner,
+  REGISTRY_ADDRESS,
+  resetNetwork,
+} from "./utils";
+import { registerValidatorAndAddToGroupMembers, registerValidatorGroup } from "./utils-validators";
+
+after(() => {
+  hre.kit.stop();
+});
+
+describe("Account - realisable capacity & rescue", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapshotId: any;
+
+  let election: ElectionWrapper;
+
+  let account: Account;
+
+  let owner: SignerWithAddress;
+  let manager: SignerWithAddress;
+  let beneficiary: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
+  let groups: SignerWithAddress[];
+  let groupAddresses: string[];
+
+  before(async () => {
+    await resetNetwork();
+
+    [manager] = await randomSigner(parseUnits("11000000"));
+    [beneficiary] = await randomSigner(parseUnits("100"));
+    [nonOwner] = await randomSigner(parseUnits("100"));
+
+    // Attach to MockRegistry so subsequent contractkit calls resolve against
+    // the test network registry. Reference itself isn't used directly.
+    const registryFactory: MockRegistry__factory = (
+      await hre.ethers.getContractFactory("MockRegistry")
+    ).connect(manager) as MockRegistry__factory;
+    registryFactory.attach(REGISTRY_ADDRESS);
+
+    groups = [];
+    groupAddresses = [];
+    for (let i = 0; i < 3; i++) {
+      const [group] = await randomSigner(parseUnits("11000"));
+      groups.push(group);
+      groupAddresses.push(group.address);
+      const [validator, validatorWallet] = await randomSigner(parseUnits("11000"));
+      await registerValidatorGroup(group);
+      await registerValidatorAndAddToGroupMembers(group, validator, validatorWallet);
+    }
+
+    await hre.deployments.fixture("TestAccount");
+    owner = await hre.ethers.getNamedSigner("owner");
+    account = await hre.ethers.getContract("Account");
+    await account.connect(owner).setManager(manager.address);
+    await account.connect(owner).setPauser();
+
+    election = await hre.kit.contracts.getElection();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await hre.ethers.provider.send("evm_snapshot", []);
+  });
+
+  afterEach(async () => {
+    await hre.ethers.provider.send("evm_revert", [snapshotId]);
+  });
+
+  /**
+   * Compute proper Election sorted-list hints for activating a vote on
+   * `group` from `account`, then call `Account.activateAndVote`.
+   */
+  async function activateOnGroup(group: string, amount: string): Promise<void> {
+    const { lesser, greater } = await election.findLesserAndGreaterAfterVote(
+      group,
+      new BigNumberJs(amount)
+    );
+    await account.connect(manager).activateAndVote(group, lesser, greater);
+  }
+
+  /**
+   * Build active votes on `group`: deposit `amount`, activate (this epoch),
+   * mine to next epoch, activate again so pending becomes active.
+   */
+  async function activateGroupWithAmount(group: string, amount: string): Promise<void> {
+    await account
+      .connect(manager)
+      .scheduleVotes([group], [parseUnits(amount)], { value: parseUnits(amount) });
+    await activateOnGroup(group, parseUnits(amount).toString());
+    await mineToNextEpoch(hre.web3);
+    await activateOnGroup(group, "0");
+  }
+
+  describe("#getRealisableCeloForGroup() - root cause", () => {
+    it("includes scheduledToVote when Election cap has headroom (matches getCeloForGroup)", async () => {
+      await account
+        .connect(manager)
+        .scheduleVotes([groupAddresses[0]], [parseUnits("100")], { value: parseUnits("100") });
+      // Don't activate. toVote = 100, active = 0, headroom > 0.
+
+      // Realisable should include the activatable toVote since Election can
+      // accept it; the activate-and-vote bot will convert to active votes.
+      expect(await account.getRealisableCeloForGroup(groupAddresses[0])).to.equal(
+        parseUnits("100")
+      );
+      expect(await account.getCeloForGroup(groupAddresses[0])).to.equal(parseUnits("100"));
+    });
+
+    it("subtracts earmarked toRevoke and toWithdraw", async () => {
+      await activateGroupWithAmount(groupAddresses[0], "100");
+
+      // Earmark 30 as a scheduled withdrawal.
+      await account
+        .connect(manager)
+        .scheduleWithdrawals(beneficiary.address, [groupAddresses[0]], [parseUnits("30")]);
+
+      // Realisable drops by the earmarked 30.
+      expect(await account.getRealisableCeloForGroup(groupAddresses[0])).to.equal(parseUnits("70"));
+    });
+
+    it("returns zero when all capacity is earmarked", async () => {
+      await activateGroupWithAmount(groupAddresses[0], "100");
+      await account
+        .connect(manager)
+        .scheduleWithdrawals(beneficiary.address, [groupAddresses[0]], [parseUnits("100")]);
+      expect(await account.getRealisableCeloForGroup(groupAddresses[0])).to.equal(0);
+    });
+
+    it("excludes unbacked scheduledToVote when Account.balance does not back it (root cause)", async () => {
+      // ROOT CAUSE PROOF.
+      //
+      // Production scenario (mainnet 0x81AE): `scheduledVotes[group].toVote`
+      // exists but `Account.balance` cannot back it - either the bot's
+      // activateAndVote silently failed (Election cap exhausted) and
+      // matching balance was consumed by other groups' activates over
+      // time, or an in-flight `scheduleTransfer(A -> B)` queued `toVote[B]`
+      // before the matching `toRevoke[A]` was physically revoked
+      // (CELO still locked under A).
+      //
+      // Either way, `Account.withdraw`'s immediate path serves only
+      // `min(balance, toVote)`, and the remainder needs `revokable`.
+      // Pre-fix `scheduleWithdrawals` validated against
+      // `getCeloForGroup = active + toVote` and let withdrawals through
+      // that the bot could never deliver, pinning users.
+      //
+      // Reproduce deterministically via `scheduleTransfer`: it adds
+      // `toVote[B]` without touching `Account.balance`. With balance = 0
+      // and revokable(B) = 0, `getRealisableCeloForGroup(B)` must be 0.
+      await activateGroupWithAmount(groupAddresses[0], "100");
+
+      const startingBalance = await hre.ethers.provider.getBalance(account.address);
+      expect(startingBalance).to.equal(0, "test setup: balance must be zero pre-transfer");
+
+      // Transfer 50 toVote from group[0] to group[1]. group[0]'s active is
+      // earmarked as toRevoke, group[1] gets toVote without any new balance.
+      await account
+        .connect(manager)
+        .scheduleTransfer(
+          [groupAddresses[0]],
+          [parseUnits("50")],
+          [groupAddresses[1]],
+          [parseUnits("50")]
+        );
+
+      // group[1] now has toVote = 50 but no Account.balance, no revokable.
+      expect(await account.scheduledVotesForGroup(groupAddresses[1])).to.equal(parseUnits("50"));
+      expect(
+        await election.getTotalVotesForGroupByAccount(groupAddresses[1], account.address)
+      ).to.equal(0);
+      expect(await hre.ethers.provider.getBalance(account.address)).to.equal(0);
+
+      // Inflated (legacy getCeloForGroup) counts toVote -> 50.
+      const inflated = await account.getCeloForGroup(groupAddresses[1]);
+      expect(inflated).to.equal(parseUnits("50"));
+
+      // Realisable excludes unbacked toVote (balance cap = 0) -> 0.
+      const realisable = await account.getRealisableCeloForGroup(groupAddresses[1]);
+      expect(realisable).to.equal(0);
+
+      // scheduleWithdrawals against the unbacked promise must revert at
+      // boundary - exactly what stops the stuck pin.
+      await expect(
+        account
+          .connect(manager)
+          .scheduleWithdrawals(beneficiary.address, [groupAddresses[1]], [parseUnits("50")])
+      ).revertedWith(`WithdrawalAmountTooHigh("${groupAddresses[1]}", 0, ${parseUnits("50")})`);
+    });
+  });
+
+  describe("#scheduleWithdrawals() - prevention of stuck pin", () => {
+    it("reverts when scheduled amount exceeds realisable", async () => {
+      // Setup: 100 CELO active votes on group[0]. realisable == 100.
+      await activateGroupWithAmount(groupAddresses[0], "100");
+      // Scheduling 101 CELO exceeds realisable -> revert at the boundary
+      // BEFORE stCelo is burned, so user never gets stuck.
+      await expect(
+        account
+          .connect(manager)
+          .scheduleWithdrawals(beneficiary.address, [groupAddresses[0]], [parseUnits("101")])
+      ).revertedWith(
+        `WithdrawalAmountTooHigh("${groupAddresses[0]}", ${parseUnits("100")}, ${parseUnits(
+          "101"
+        )})`
+      );
+    });
+
+    it("subtracts an existing toWithdraw ONCE from combined capacity, not per bucket", async () => {
+      // Regression for the double-subtraction bug (review by Mc01).
+      //
+      // A group with BOTH buckets non-empty: 100 active votes (revoke bucket)
+      // plus 50 balance-backed toVote (immediate bucket). Combined physical
+      // capacity C = revokable(100) + min(balance 50, toVote 50) = 150.
+      await activateGroupWithAmount(groupAddresses[0], "100"); // active=100, toVote=0, balance=0
+      await account
+        .connect(manager)
+        .scheduleVotes([groupAddresses[0]], [parseUnits("50")], { value: parseUnits("50") });
+      // toVote=50 backed by balance=50, revokable=100, toRevoke=0.
+
+      // Pin an existing withdrawal W = 50 on the group.
+      await account
+        .connect(manager)
+        .scheduleWithdrawals(beneficiary.address, [groupAddresses[0]], [parseUnits("50")]);
+
+      // Account.withdraw is immediate-first, so W consumes the COMBINED
+      // capacity once. Realisable for a new pin = C - W = 150 - 50 = 100.
+      // The buggy double-subtraction reported 50 (revokable-W=50 plus
+      // immediate min(balance, toVote-W)=0), wrongly hiding 50 of real
+      // capacity.
+      expect(await account.getRealisableCeloForGroup(groupAddresses[0])).to.equal(
+        parseUnits("100")
+      );
+
+      // A second withdrawal of exactly C - W = 100 must schedule. Pre-fix this
+      // reverted WithdrawalAmountTooHigh(group, 50, 100) - a serviceable
+      // withdrawal wrongly rejected.
+      await account
+        .connect(manager)
+        .scheduleWithdrawals(nonOwner.address, [groupAddresses[0]], [parseUnits("100")]);
+
+      // Now the whole capacity (150) is earmarked; one wei more reverts.
+      await expect(
+        account.connect(manager).scheduleWithdrawals(beneficiary.address, [groupAddresses[0]], [1])
+      ).revertedWith(`WithdrawalAmountTooHigh("${groupAddresses[0]}", 0, 1)`);
+    });
+
+    it("guarantees Account.withdraw fulfills any successfully scheduled amount", async () => {
+      // After scheduling passes, the bot's Account.withdraw must succeed via
+      // immediate + revoke path. Invariant: scheduled <= realisable =>
+      // revokable + activatable >= scheduled.
+      await activateGroupWithAmount(groupAddresses[0], "100");
+      await account
+        .connect(manager)
+        .scheduleWithdrawals(beneficiary.address, [groupAddresses[0]], [parseUnits("100")]);
+
+      const votedGroups = await election.getGroupsVotedForByAccount(account.address);
+      const voterIndex = votedGroups.findIndex(
+        (g) => g.toLowerCase() === groupAddresses[0].toLowerCase()
+      );
+      const { lesser, greater } = await election.findLesserAndGreaterAfterVote(
+        groupAddresses[0],
+        new BigNumberJs(parseUnits("-100").toString())
+      );
+      await account.withdraw(
+        beneficiary.address,
+        groupAddresses[0],
+        ADDRESS_ZERO,
+        ADDRESS_ZERO,
+        lesser,
+        greater,
+        voterIndex
+      );
+
+      // Scheduled withdrawal cleared, no stuck state.
+      expect(
+        await account.scheduledWithdrawalsForGroupAndBeneficiary(
+          groupAddresses[0],
+          beneficiary.address
+        )
+      ).to.equal(0);
+    });
+  });
+
+  describe("#rescueScheduledWithdrawal() - permissionless deficit rescue", () => {
+    async function setupScheduledWithdrawal(amount: string): Promise<void> {
+      await activateGroupWithAmount(groupAddresses[0], amount);
+      await account
+        .connect(manager)
+        .scheduleWithdrawals(beneficiary.address, [groupAddresses[0]], [parseUnits(amount)]);
+    }
+
+    it("reverts GroupNotInDeficit when fromGroup can still fulfill THIS beneficiary's pin", async () => {
+      // Schedule a per-beneficiary pin where Account.withdraw could
+      // physically deliver it (revokable + immediate >= userClaim).
+      // Permissionless rescue must reject so a griefer cannot reroute a
+      // payable withdrawal to slower-unbond groups.
+      await setupScheduledWithdrawal("100");
+      await activateGroupWithAmount(groupAddresses[1], "200");
+      // capacity(group[0]) = revokable(100) + immediate(0) = 100.
+      // userClaim = 100. capacity >= userClaim -> NOT in deficit.
+      await expect(
+        account
+          .connect(nonOwner)
+          .rescueScheduledWithdrawal(
+            beneficiary.address,
+            groupAddresses[0],
+            [groupAddresses[1]],
+            [parseUnits("100")]
+          )
+      ).revertedWith(
+        `GroupNotInDeficit("${beneficiary.address}", "${groupAddresses[0]}", ${parseUnits(
+          "100"
+        )}, ${parseUnits("100")})`
+      );
+    });
+
+    it("reverts NoScheduledWithdrawal when beneficiary has no pin on fromGroup", async () => {
+      // No prior schedule on groupAddresses[0] for beneficiary -> revert
+      // happens BEFORE the deficit check (cheap input validation).
+      await expect(
+        account
+          .connect(nonOwner)
+          .rescueScheduledWithdrawal(
+            beneficiary.address,
+            groupAddresses[0],
+            [groupAddresses[1]],
+            [parseUnits("100")]
+          )
+      ).revertedWith(`NoScheduledWithdrawal("${beneficiary.address}", "${groupAddresses[0]}")`);
+    });
+
+    it("reverts on toGroups/amounts length mismatch", async () => {
+      await setupScheduledWithdrawal("100");
+      await expect(
+        account
+          .connect(nonOwner)
+          .rescueScheduledWithdrawal(
+            beneficiary.address,
+            groupAddresses[0],
+            [groupAddresses[1], groupAddresses[2]],
+            [parseUnits("100")]
+          )
+      ).revertedWith("GroupsAndVotesArrayLengthsMismatch()");
+    });
+  });
+});

--- a/test-ts/default-strategy.test.ts
+++ b/test-ts/default-strategy.test.ts
@@ -1258,7 +1258,7 @@ describe("DefaultStrategy", () => {
   describe("#generateWithdrawalVoteDistribution", () => {
     it("cannot be called by a non-Manager address", async () => {
       await expect(
-        defaultStrategyContract.connect(nonManager).generateWithdrawalVoteDistribution(10)
+        defaultStrategyContract.connect(nonManager).generateWithdrawalVoteDistribution(10, false)
       ).revertedWith(`CallerNotManagerNorStrategy("${nonManager.address}")`);
     });
   });

--- a/test-ts/end-to-end-stuck-withdrawal.test.ts
+++ b/test-ts/end-to-end-stuck-withdrawal.test.ts
@@ -1,0 +1,1030 @@
+// End-to-end regression test for the "stuck withdrawal" root cause.
+//
+// REAL contracts only - no mocks. Reproduces the production scenario where
+// a validator group's scheduled votes can no longer be voted because an
+// external voter saturated the Election cap. The activate-bot silently
+// skips the group, scheduledVotes.toVote stays bloated, and `getCeloForGroup`
+// reports inflated capacity. Pre-fix this caused `Manager.withdraw` to
+// schedule a withdrawal that the bot's `Account.withdraw` would later revert
+// with `InsufficientRevokableVotes`, permanently pinning user CELO.
+//
+// Verifies the load-bearing mitigations end-to-end:
+//   1. PREVENTION - `Account.scheduleWithdrawals` rejects pins above
+//      realisable capacity (via `getRealisableCeloForGroup`), so the user's
+//      stCELO is NEVER burned into an unfulfillable pin.
+//   2. RESCUE - `Account.rescueScheduledWithdrawal` (permissionless) re-routes
+//      any pre-existing pin to groups with capacity when the source group is
+//      provably in deficit for the beneficiary.
+//   3. CLEANUP - `DefaultStrategy.rebalanceOverallocatedGroup` drains a
+//      bloated group's stCELO allocation back to other active groups.
+
+import { ElectionWrapper } from "@celo/contractkit/lib/wrappers/Election";
+import { LockedGoldWrapper } from "@celo/contractkit/lib/wrappers/LockedGold";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import BigNumberJs from "bignumber.js";
+import { expect } from "chai";
+import { parseUnits } from "ethers/lib/utils";
+import hre from "hardhat";
+import { Account } from "../typechain-types/Account";
+import { DefaultStrategy } from "../typechain-types/DefaultStrategy";
+import { GroupHealth } from "../typechain-types/GroupHealth";
+import { Manager } from "../typechain-types/Manager";
+import { MockGroupHealth } from "../typechain-types/MockGroupHealth";
+import { SpecificGroupStrategy } from "../typechain-types/SpecificGroupStrategy";
+import { StakedCelo } from "../typechain-types/StakedCelo";
+import {
+  activateAndVoteTest,
+  prepareOverflow,
+  randomSigner,
+  resetNetwork,
+  upgradeToMockGroupHealthE2E,
+} from "./utils";
+import {
+  activateValidators,
+  electMockValidatorGroupsAndUpdate,
+  registerValidatorAndAddToGroupMembers,
+  registerValidatorGroup,
+} from "./utils-validators";
+
+after(() => {
+  hre.kit.stop();
+});
+
+describe("e2e stuck-withdrawal regression", () => {
+  let accountContract: Account;
+  let managerContract: Manager;
+  let groupHealthContract: MockGroupHealth;
+  let specificGroupStrategyContract: SpecificGroupStrategy;
+  let defaultStrategy: DefaultStrategy;
+  let stakedCelo: StakedCelo;
+  let election: ElectionWrapper;
+  let lockedGold: LockedGoldWrapper;
+
+  let depositor: SignerWithAddress;
+  let secondDepositor: SignerWithAddress;
+  let voter: SignerWithAddress;
+  let randomCaller: SignerWithAddress;
+  let multisigOwner0: SignerWithAddress;
+
+  let groups: SignerWithAddress[];
+  let activatedGroupAddresses: string[];
+
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-explicit-any
+  before(async function (this: any) {
+    this.timeout(0);
+    await resetNetwork();
+
+    process.env = {
+      ...process.env,
+      TIME_LOCK_MIN_DELAY: "1",
+      TIME_LOCK_DELAY: "1",
+      MULTISIG_REQUIRED_CONFIRMATIONS: "1",
+      VALIDATOR_GROUPS: "",
+    };
+
+    [depositor] = await randomSigner(parseUnits("10000"));
+    [secondDepositor] = await randomSigner(parseUnits("10000"));
+    [voter] = await randomSigner(parseUnits("10000000000"));
+    [randomCaller] = await randomSigner(parseUnits("100"));
+
+    const accounts = await hre.kit.contracts.getAccounts();
+    await accounts.createAccount().sendAndWaitForReceipt({ from: voter.address });
+
+    groups = [];
+    activatedGroupAddresses = [];
+    for (let i = 0; i < 11; i++) {
+      const [g] = await randomSigner(parseUnits("21000"));
+      groups.push(g);
+    }
+    for (let i = 0; i < 11; i++) {
+      if (i === 1) {
+        await registerValidatorGroup(groups[i], 2);
+        const [v, w] = await randomSigner(parseUnits("11000"));
+        await registerValidatorAndAddToGroupMembers(groups[i], v, w);
+      } else {
+        await registerValidatorGroup(groups[i], 1);
+      }
+      if (i < 3) activatedGroupAddresses.push(groups[i].address);
+      const [v, w] = await randomSigner(parseUnits("11000"));
+      await registerValidatorAndAddToGroupMembers(groups[i], v, w);
+    }
+  });
+
+  beforeEach(async () => {
+    await hre.deployments.fixture("core");
+    accountContract = await hre.ethers.getContract("Account");
+    managerContract = await hre.ethers.getContract("Manager");
+    groupHealthContract = await hre.ethers.getContract("GroupHealth");
+    specificGroupStrategyContract = await hre.ethers.getContract("SpecificGroupStrategy");
+    defaultStrategy = await hre.ethers.getContract("DefaultStrategy");
+    stakedCelo = await hre.ethers.getContract("StakedCelo");
+    lockedGold = await hre.kit.contracts.getLockedGold();
+    election = await hre.kit.contracts.getElection();
+
+    multisigOwner0 = await hre.ethers.getNamedSigner("multisigOwner0");
+
+    groupHealthContract = await upgradeToMockGroupHealthE2E(
+      multisigOwner0,
+      groupHealthContract as unknown as GroupHealth
+    );
+    const validatorWrapper = await hre.kit.contracts.getValidators();
+    await electMockValidatorGroupsAndUpdate(validatorWrapper, groupHealthContract, [
+      ...activatedGroupAddresses,
+      groups[5].address,
+    ]);
+
+    await activateValidators(
+      defaultStrategy,
+      groupHealthContract as unknown as GroupHealth,
+      multisigOwner0,
+      activatedGroupAddresses
+    );
+
+    // Burn through Election cap on groups[0..2] so the per-group voting
+    // limit is small (~40-200 CELO). This is the same setup the existing
+    // e2e overflow test uses to deterministically trigger "scheduled votes
+    // not activatable" via a follow-up external vote.
+    await prepareOverflow(
+      defaultStrategy,
+      election,
+      lockedGold,
+      voter,
+      activatedGroupAddresses,
+      false
+    );
+
+    // Pre-lock a big chunk of voter CELO so per-test `externalVoterSaturates`
+    // calls don't move `numVotesReceivable` (the cap formula scales with
+    // total locked gold). Locking up-front keeps the cap stable for the
+    // subsequent vote.
+    await lockedGold.lock().sendAndWaitForReceipt({
+      from: voter.address,
+      value: parseUnits("100000").toString(),
+    });
+  });
+
+  /**
+   * Trigger the bug condition: external voter votes the remaining cap PLUS
+   * the protocol's current scheduledToVote for `group`. After this call,
+   * `Election.canReceiveVotes(group, X)` returns false for any positive X,
+   * so the activate-bot silently skips the group and `scheduledVotes.toVote`
+   * accumulates without ever becoming active votes. This is the exact
+   * mechanism that bloated `0x81AE...` on mainnet.
+   */
+  async function externalVoterSaturatesGroup(group: string): Promise<void> {
+    // Voter already has 100k CELO locked (from beforeEach). Measure the
+    // current receivable + protocol-scheduled and vote that exact amount;
+    // voting won't change `numVotesReceivable` (only locking does), so
+    // headroom drops to zero and stays there.
+    const receivable = await managerContract.getReceivableVotesForGroup(group);
+    const scheduled = await accountContract.scheduledVotesForGroup(group);
+    const total = receivable.add(scheduled);
+    if (total.lte(0)) return;
+    const voteTx = await election.vote(group, new BigNumberJs(total.toString()));
+    await voteTx.sendAndWaitForReceipt({ from: voter.address });
+  }
+
+  // EXACT mainnet 0x81AE shape reproduction. Uses scheduleTransfer (not
+  // scheduleVotes) to inject the UNBACKED toVote that mainnet reached via
+  // accumulated transfer / cap-exhaustion history: target group has toVote
+  // bookkeeping with no matching Account.balance and no revokable Election
+  // votes. scheduleWithdrawals validates against getRealisableCeloForGroup
+  // which excludes unbacked toVote (balance cap = 0) -> reverts with
+  // WithdrawalAmountTooHigh, preventing the stuck pin at the boundary.
+  it("PREVENTION (EXACT root-cause shape, forum.celo.org/t/.../13333): scheduleWithdrawals reverts when group's toVote is not backed by Account.balance", async () => {
+    // a. depositor default-deposits enough to spread allocation across
+    //    multiple default groups, then activate-bot votes -> real active
+    //    votes on each. Account.balance drained into LockedGold.
+    await managerContract.connect(depositor).deposit({ value: parseUnits("60") });
+    await managerContract.connect(secondDepositor).deposit({ value: parseUnits("60") });
+    await activateAndVoteTest();
+
+    const balancePostActivate = await hre.ethers.provider.getBalance(accountContract.address);
+    expect(balancePostActivate.eq(0)).to.equal(
+      true,
+      "test setup: Account.balance must be drained by activate so toVote injection stays unbacked"
+    );
+
+    // Find a default group (NOT groups[2], which is the destination) with
+    // positive active votes to be the scheduleTransfer source. Use the
+    // smallest viable amount to fit any single group's allocation.
+    let sourceGroup: string | undefined;
+    let sourceCelo = hre.ethers.BigNumber.from(0);
+    for (const g of activatedGroupAddresses) {
+      if (g === groups[5].address) continue;
+      const celoForG = await accountContract.getCeloForGroup(g);
+      if (celoForG.gt(sourceCelo)) {
+        sourceGroup = g;
+        sourceCelo = celoForG;
+      }
+    }
+    expect(sourceCelo.gt(0)).to.equal(
+      true,
+      "test setup: no default group (excluding dest) has any active capacity to serve as transfer source"
+    );
+    const staleToVote = sourceCelo.lt(parseUnits("20")) ? sourceCelo : parseUnits("20");
+
+    // b. Manager-impersonate scheduleTransfer to move toVote bookkeeping
+    //    onto groups[2] (destination) WITHOUT touching Account.balance.
+    //    This matches the in-flight-transfer shape mainnet 0x81AE reached
+    //    organically.
+    const managerSigner = await asManager();
+    await accountContract
+      .connect(managerSigner)
+      .scheduleTransfer([sourceGroup as string], [staleToVote], [groups[5].address], [staleToVote]);
+
+    // c. SANITY: groups[2] has toVote bookkeeping but no balance and no
+    //    revokable Election votes. getCeloForGroup inflated by stale
+    //    toVote; getRealisableCeloForGroup discards it via balance cap.
+    expect(await accountContract.scheduledVotesForGroup(groups[5].address)).to.equal(staleToVote);
+    const inflated = await accountContract.getCeloForGroup(groups[5].address);
+    const realisable = await accountContract.getRealisableCeloForGroup(groups[5].address);
+    expect(inflated.gte(staleToVote)).to.equal(true, "inflated must include stale toVote");
+    expect(realisable.eq(0)).to.equal(
+      true,
+      `realisable must be 0 for unbacked toVote, got ${realisable}`
+    );
+
+    // d. Manager-impersonate scheduleWithdrawals against the unbacked pin.
+    //    Pre-fix: validation against getCeloForGroup PASSES, stCELO burned,
+    //    bot later stuck. Post-fix: validation uses getRealisableCeloForGroup,
+    //    sees 0 capacity, reverts WithdrawalAmountTooHigh. stCELO never
+    //    burned, user never pinned.
+    await expect(
+      accountContract
+        .connect(managerSigner)
+        .scheduleWithdrawals(depositor.address, [groups[5].address], [staleToVote])
+    ).revertedWith(`WithdrawalAmountTooHigh("${groups[5].address}", 0, ${staleToVote})`);
+
+    // e. No pin was created.
+    expect(
+      await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(
+        groups[5].address,
+        depositor.address
+      )
+    ).to.equal(0);
+  });
+
+  /**
+   * Helper: impersonate Manager to call onlyManager Account functions.
+   * Lets tests set up exact Account state (toVote inflation, earmarks)
+   * that would normally require many natural deposit/strategy events.
+   */
+  async function asManager() {
+    const managerAddr = managerContract.address;
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [managerAddr],
+    });
+    await hre.network.provider.send("hardhat_setBalance", [
+      managerAddr,
+      "0x10000000000000000000000",
+    ]);
+    return await hre.ethers.getSigner(managerAddr);
+  }
+
+  it("STRATEGY-SWAP (SpecificGroupStrategy:364): SGS reverts GroupNotBalanced (NOT WithdrawalAmountTooHigh) when overflow remainder exceeds realisable", async () => {
+    // SGS line 364 uses getRealisableCeloForGroup (post-swap) to check
+    // the overflow remainder. Without the swap, SGS would use the
+    // inflated getCeloForGroup, pass through to Account.scheduleWithdrawals
+    // which fires WithdrawalAmountTooHigh - different error. The asserted
+    // GroupNotBalanced revert is what only the swap produces.
+
+    // a0. secondDepositor builds active votes on multiple default groups
+    //     so DS overflow distribution (called from SGS later) has capacity
+    //     to absorb the overflow withdrawal portion.
+    await managerContract.connect(secondDepositor).deposit({ value: parseUnits("50") });
+    await activateAndVoteTest();
+
+    // a. Build active votes on groups[1] BEFORE saturation.
+    await managerContract.connect(depositor).changeStrategy(groups[1].address);
+    await managerContract.connect(depositor).deposit({ value: parseUnits("50") });
+    await activateAndVoteTest();
+
+    // b. Saturate groups[1] cap so subsequent deposit overflows.
+    await externalVoterSaturatesGroup(groups[1].address);
+
+    // c. Tiny extra deposit overflows to default, recording
+    //    stCeloInGroupOverflowed[g[1]] > 0. Keep small so DS overflow
+    //    distribution can satisfy the matching withdrawal.
+    await managerContract.connect(depositor).deposit({ value: parseUnits("10") });
+    const [, overflowStCelo] = await specificGroupStrategyContract.getStCeloInGroup(
+      groups[1].address
+    );
+    expect(overflowStCelo.gt(0)).to.equal(true, "test setup invalid: SGS overflow not recorded");
+
+    // d. Earmark a separate scheduled withdrawal on g[1] so realisable
+    //    drops BELOW the post-overflow remainder. Earmark 30 fits within
+    //    current realisable (~50 active) so the load-bearing Account
+    //    check at scheduleWithdrawals doesn't revert here.
+    const managerSigner = await asManager();
+    await accountContract
+      .connect(managerSigner)
+      .scheduleWithdrawals(voter.address, [groups[1].address], [parseUnits("30")]);
+
+    const realisable = await accountContract.getRealisableCeloForGroup(groups[1].address);
+    expect(realisable.lt(parseUnits("50"))).to.equal(
+      true,
+      "test setup invalid: realisable must be < remainder for SGS swap to fire"
+    );
+
+    // e. depositor.withdraw the full position (~60 CELO).
+    //    SGS overflow branch:
+    //      - celoToBeMovedFromDefaultStrategy ≈ 10 (overflow portion)
+    //      - celoWithdrawalAmount remainder ≈ 50 (specific portion)
+    //    realisable(g[1]) after earmark ≈ 20.
+    //    Remainder(50) > realisable(20) -> SGS line 364 fires
+    //    GroupNotBalanced (with swap). Without swap: SGS passes,
+    //    Account.scheduleWithdrawals fires WithdrawalAmountTooHigh.
+    const stCeloBefore = await stakedCelo.balanceOf(depositor.address);
+    await expect(managerContract.connect(depositor).withdraw(stCeloBefore)).revertedWith(
+      `GroupNotBalanced("${groups[1].address}")`
+    );
+  });
+
+  it("STRATEGY-SWAP (DefaultStrategy:530): DS distribution caps allocation by realisable, splitting withdrawal across groups instead of pinning to over-allocated HEAD", async () => {
+    // With swap: DS distribution caps per-group allocation by realisable;
+    // spillover routed to siblings; Manager.withdraw succeeds.
+    // Without swap: DS allocates inflated amount to HEAD; Account swap at
+    // scheduleWithdrawals rejects with WithdrawalAmountTooHigh.
+
+    // a. Build allocation across multiple groups so siblings can absorb
+    //    spillover.
+    await managerContract.connect(depositor).deposit({ value: parseUnits("30") });
+    await managerContract.connect(depositor).deposit({ value: parseUnits("30") });
+    await activateAndVoteTest();
+    const [headGroup] = await defaultStrategy.getGroupsHead();
+
+    // b. Earmark some HEAD capacity for another beneficiary so realisable
+    //    < toCelo(stCeloInGroup) - the swap binding term.
+    const managerSigner = await asManager();
+    await accountContract
+      .connect(managerSigner)
+      .scheduleWithdrawals(voter.address, [headGroup], [parseUnits("10")]);
+
+    const realisableBefore = await accountContract.getRealisableCeloForGroup(headGroup);
+    const stCeloAlloc = await defaultStrategy.stCeloInGroup(headGroup);
+    const toCeloAlloc = await managerContract.toCelo(stCeloAlloc);
+    expect(toCeloAlloc.gt(realisableBefore)).to.equal(
+      true,
+      "test setup invalid: toCelo(stCeloInGroup) must exceed realisable for swap to matter"
+    );
+
+    // c. Withdraw a SMALL amount just over realisable so spillover fits
+    //    sibling groups. With swap: distribution caps HEAD at realisable
+    //    and routes spillover. Without swap: HEAD over-allocated, Account
+    //    validation reverts.
+    const withdrawCelo = realisableBefore.add(parseUnits("2"));
+    const withdrawStCelo = await managerContract.toStakedCelo(withdrawCelo);
+    await managerContract.connect(depositor).withdraw(withdrawStCelo);
+
+    // d. Per-group cap on HEAD <= pre-call realisable. Without DS swap,
+    //    HEAD would have been allocated more (or Manager.withdraw would
+    //    have reverted upstream, failing the line above).
+    const scheduledOnHead = await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(
+      headGroup,
+      depositor.address
+    );
+    expect(scheduledOnHead.lte(realisableBefore)).to.equal(
+      true,
+      `scheduledOnHead(${scheduledOnHead}) > realisable(${realisableBefore}) - DS swap not enforced`
+    );
+  });
+
+  it("REGRESSION P1: scheduleWithdrawals must reject unbacked toVote from in-flight transfer", async () => {
+    // Codex P1 finding. After Account.scheduleTransfer(A -> B, X) the protocol
+    // sets toRevoke[A] = X and toVote[B] = X but the matching CELO is still
+    // locked under A in LockedGold (Account.balance ≈ 0). Until the activate-bot
+    // executes the revoke on A AND the new vote on B, B's toVote is "unbacked":
+    // no Account.balance, no revokable(B), only future-intent bookkeeping.
+    //
+    // Current getRealisableCeloForGroup formula:
+    //   revokable + min(toVote, electionHeadroom)
+    // For B: 0 + min(X, big_headroom) = X. So scheduleWithdrawals(B, X) PASSES.
+    // Bot's Account.withdraw(B):
+    //   immediateWithdrawalAmount = min(balance=0, toVote_B) = 0
+    //   revokeAmount = X
+    //   _revokeVotes(B, X) -> revokable(B)=0 -> InsufficientRevokableVotes
+    // -> new stuck pin in the rebalance window. Same class of bug as the
+    // 0x81AE forum case, just triggered via scheduleTransfer instead of
+    // deposit + cap-exhaustion.
+    //
+    // Required behavior: scheduleWithdrawals MUST reject at the boundary so
+    // no pin is created. Test asserts the revert.
+
+    // a. Build real active votes on groups[0] so scheduleTransfer's
+    //    getCeloForGroup(A) validation passes and CELO is locked in LockedGold.
+    await managerContract.connect(depositor).changeStrategy(groups[0].address);
+    await managerContract.connect(depositor).deposit({ value: parseUnits("30") });
+    await activateAndVoteTest();
+
+    const celoForA = await accountContract.getCeloForGroup(groups[0].address);
+    expect(celoForA.gte(parseUnits("20"))).to.equal(
+      true,
+      "test setup: A must have enough active votes for transfer"
+    );
+
+    // b. Pick B = groups[5] (registered + elected via electMockValidatorGroupsAndUpdate,
+    //    but NOT pre-saturated by prepareOverflow). Full headroom, zero protocol votes.
+    const groupB = groups[5].address;
+    const headroomB = await managerContract.getReceivableVotesForGroup(groupB);
+    expect(headroomB.gte(parseUnits("20"))).to.equal(true, "test setup: B must have headroom");
+
+    // c. Impersonate Manager to call Account.scheduleTransfer(A -> B, X).
+    //    Pure bookkeeping move. CELO does NOT move - stays locked under A
+    //    awaiting revoke.
+    const managerSigner = await asManager();
+    const transferAmt = parseUnits("20");
+    await accountContract
+      .connect(managerSigner)
+      .scheduleTransfer([groups[0].address], [transferAmt], [groupB], [transferAmt]);
+
+    // d. Confirm bug shape on B via the ethers-typed read paths.
+    const electionAbi = [
+      "function getTotalVotesForGroupByAccount(address,address) view returns (uint256)",
+    ];
+    const electionAddr = await hre.kit.registry.addressFor("Election" as never);
+    const electionEthers = new hre.ethers.Contract(electionAddr, electionAbi, hre.ethers.provider);
+    const revokableB = await electionEthers.getTotalVotesForGroupByAccount(
+      groupB,
+      accountContract.address
+    );
+    expect(revokableB.eq(0)).to.equal(true, "B has no revokable Election votes");
+
+    const balanceBefore = await hre.ethers.provider.getBalance(accountContract.address);
+    expect(balanceBefore.lt(transferAmt)).to.equal(
+      true,
+      `test setup: Account.balance (${balanceBefore}) must be insufficient to back the unbacked toVote (${transferAmt})`
+    );
+
+    const realisableB = await accountContract.getRealisableCeloForGroup(groupB);
+    // CURRENT (buggy) code reports realisableB ≈ transferAmt. POST-FIX
+    // (drop unbacked toVote contribution) reports 0. Either way, the next
+    // assertion - that scheduleWithdrawals reverts - is the load-bearing one.
+
+    // e. scheduleWithdrawals(beneficiary, B, transferAmt). Bot's later
+    //    Account.withdraw(B) would revert InsufficientRevokableVotes since
+    //    revokable(B)=0 and balance≈0. Required: revert at boundary so no
+    //    pin is ever created.
+    await expect(
+      accountContract
+        .connect(managerSigner)
+        .scheduleWithdrawals(depositor.address, [groupB], [transferAmt])
+    ).reverted;
+
+    // f. No pin created.
+    expect(
+      await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(groupB, depositor.address)
+    ).to.equal(0);
+
+    // g. Diagnostic surface for the PR conversation.
+    // eslint-disable-next-line no-console
+    console.log(
+      `[P1] realisable(B)=${realisableB} revokable(B)=${revokableB} balance=${balanceBefore} transferAmt=${transferAmt}`
+    );
+  });
+
+  it("REGRESSION P2: distribution loop must skip zero-realisable HEAD instead of wedging", async () => {
+    // Codex P2 finding. When sorted HEAD has stCeloInGroup > 0 but
+    // getRealisableCeloForGroup returns 0:
+    //   votes[i] = min(min(0, toCelo(stCelo)), celoAmount) = 0
+    //   _updateGroupStCelo(HEAD, toStakedCelo(0)=0, false) - no-op
+    //   trySort(HEAD, unchanged, false) - position unchanged, sorted stays true
+    //   sorted -> votedGroup = activeGroups.getHead() (SAME)
+    //   groupsIndex++ - slot burned
+    // After maxGroupsToWithdrawFrom iterations: celoAmount != 0 ->
+    // NotAbleToDistributeVotes. Distribution wedges even when tail groups
+    // have plenty of capacity. Regression introduced by this PR - pre-fix
+    // getCeloForGroup almost never returned 0 because toVote padded it.
+    //
+    // Required behavior: skip zero-realisable group without consuming a
+    // slot or re-selecting HEAD; allocate remainder from tail groups.
+
+    // a. Spread stCELO across all three active groups via two depositors.
+    await managerContract.connect(depositor).deposit({ value: parseUnits("30") });
+    await managerContract.connect(secondDepositor).deposit({ value: parseUnits("30") });
+    await activateAndVoteTest();
+
+    const [headGroup] = await defaultStrategy.getGroupsHead();
+    const headStCeloBefore = await defaultStrategy.stCeloInGroup(headGroup);
+    expect(headStCeloBefore.gt(0)).to.equal(true);
+
+    // b. Drain HEAD's realisable to 0 by earmarking the full revokable to a
+    //    separate beneficiary. stCeloInGroup[HEAD] is UNCHANGED so HEAD
+    //    remains HEAD of the sorted list.
+    const realisableHeadBefore = await accountContract.getRealisableCeloForGroup(headGroup);
+    expect(realisableHeadBefore.gt(0)).to.equal(true, "test setup: HEAD must have realisable");
+    const managerSigner = await asManager();
+    await accountContract
+      .connect(managerSigner)
+      .scheduleWithdrawals(voter.address, [headGroup], [realisableHeadBefore]);
+
+    expect(await accountContract.getRealisableCeloForGroup(headGroup)).to.equal(
+      0,
+      "test setup: HEAD realisable must be drained to 0"
+    );
+    expect(await defaultStrategy.stCeloInGroup(headGroup)).to.equal(
+      headStCeloBefore,
+      "test setup: HEAD stCelo allocation must be unchanged"
+    );
+
+    // c. Confirm HEAD is still the sorted HEAD. Otherwise the test doesn't
+    //    exercise the wedge.
+    const [headStill] = await defaultStrategy.getGroupsHead();
+    expect(headStill).to.equal(headGroup, "test setup: HEAD must still be HEAD");
+
+    // d. depositor.withdraw small amount that tail groups can satisfy.
+    //    Pre-fix: distribution loop wedges on HEAD, reverts
+    //    NotAbleToDistributeVotes. Post-fix: skips HEAD, allocates from tail.
+    const smallStCelo = parseUnits("5");
+    await managerContract.connect(depositor).withdraw(smallStCelo);
+
+    // e. HEAD must have received 0 allocation.
+    const headAlloc = await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(
+      headGroup,
+      depositor.address
+    );
+    expect(headAlloc).to.equal(0, "HEAD should have been skipped (zero realisable)");
+
+    // f. At least one tail group must have absorbed the withdrawal.
+    let tailAbsorbed = hre.ethers.BigNumber.from(0);
+    for (const g of activatedGroupAddresses) {
+      if (g === headGroup) continue;
+      tailAbsorbed = tailAbsorbed.add(
+        await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(g, depositor.address)
+      );
+    }
+    expect(tailAbsorbed.gt(0)).to.equal(true, "tail groups must have absorbed the withdrawal");
+  });
+
+  it("REGRESSION P2 #4: distribution must not return same group twice when over-allocated HEAD has stCelo > realisable", async () => {
+    // Codex follow-up finding. When realisable < stCelo for the sorted HEAD,
+    // the loop picks `capacity = realisable`, decrements stCelo, trySort
+    // keeps HEAD as HEAD (still largest), `sorted == true` re-selects
+    // getHead() = same group. realisable hasn't changed (Account state is
+    // not mutated until scheduleWithdrawals runs after distribution returns).
+    // Result: same group appears twice in (groups, votes). scheduleWithdrawals
+    // accepts the first entry (earmarks realisable), then on the second
+    // entry sees `revokable - earmarked = 0` and reverts WithdrawalAmountTooHigh.
+    // Required: each group appears at most once per distribution; spill to
+    // tail groups when HEAD's physical capacity is exhausted.
+
+    // a. Spread baseline deposit across all three active groups via three
+    //    separate small deposits. Each goes to the current TAIL (smallest
+    //    stCelo) so allocation spreads round-robin instead of all landing
+    //    on one group. After three deposits + activate, each group has
+    //    revokable Election votes (positive realisable on g0, g1, g2).
+    await managerContract.connect(depositor).deposit({ value: parseUnits("15") });
+    await managerContract.connect(depositor).deposit({ value: parseUnits("15") });
+    await managerContract.connect(depositor).deposit({ value: parseUnits("15") });
+    await activateAndVoteTest();
+
+    // b. Bloat HEAD's DefaultStrategy allocation via owner-only
+    //    updateGroupStCelo (simulates the over-allocated state from
+    //    accumulated rebalance / transferWithoutChecks events on mainnet).
+    //    Impersonate the MultiSig contract which owns DefaultStrategy.
+    const multisigAddr = (await hre.deployments.get("MultiSig")).address;
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [multisigAddr],
+    });
+    await hre.network.provider.send("hardhat_setBalance", [multisigAddr, "0x1000000000000000000"]);
+    const multisigSigner = await hre.ethers.getSigner(multisigAddr);
+    const [headGroupPre] = await defaultStrategy.getGroupsHead();
+    // Bloat the current HEAD with 500 stCELO so it stays HEAD across many
+    // decrement iterations during withdrawal distribution.
+    await defaultStrategy
+      .connect(multisigSigner)
+      .updateGroupStCelo(headGroupPre, parseUnits("500"), true);
+
+    const [headGroup] = await defaultStrategy.getGroupsHead();
+    const headStCelo = await defaultStrategy.stCeloInGroup(headGroup);
+    const headStCeloAsCelo = await managerContract.toCelo(headStCelo);
+
+    // b. Earmark almost all of HEAD's revokable so realisable drops to 1 CELO
+    //    while stCelo allocation remains huge (200 CELO equivalent).
+    const realisableBefore = await accountContract.getRealisableCeloForGroup(headGroup);
+    expect(realisableBefore.gt(parseUnits("10"))).to.equal(
+      true,
+      "test setup: HEAD needs enough realisable for partial earmark"
+    );
+    const earmarkAmount = realisableBefore.sub(parseUnits("1"));
+    const managerSigner = await asManager();
+    await accountContract
+      .connect(managerSigner)
+      .scheduleWithdrawals(voter.address, [headGroup], [earmarkAmount]);
+
+    const realisable = await accountContract.getRealisableCeloForGroup(headGroup);
+    expect(realisable.eq(parseUnits("1"))).to.equal(
+      true,
+      `test setup: realisable must be exactly 1 CELO, got ${realisable}`
+    );
+    expect(headStCeloAsCelo.gt(realisable.mul(50))).to.equal(
+      true,
+      `test setup: HEAD must dominate (stCeloAsCelo ${headStCeloAsCelo} >> realisable*50 ${realisable.mul(
+        50
+      )})`
+    );
+
+    const [headStill] = await defaultStrategy.getGroupsHead();
+    expect(headStill).to.equal(headGroup, "test setup: HEAD must still be HEAD");
+
+    // c. depositor withdraws 5 CELO. Pre-fix: distribution returns HEAD 5
+    //    times (HEAD stays HEAD across decrements, realisable doesn't shrink
+    //    in distribution), then scheduleWithdrawals reverts on the second
+    //    entry because earmarked exceeds revokable. Post-fix: HEAD allocated
+    //    once at its 1 CELO cap, remaining 4 CELO routed to tail groups.
+    const withdrawStCelo = await managerContract.toStakedCelo(parseUnits("5"));
+    await managerContract.connect(depositor).withdraw(withdrawStCelo);
+
+    // d. HEAD allocated at most its realisable cap.
+    const headPin = await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(
+      headGroup,
+      depositor.address
+    );
+    expect(headPin.lte(realisable)).to.equal(
+      true,
+      `HEAD pin ${headPin} exceeded realisable ${realisable}`
+    );
+
+    // e. Some tail group absorbed the spill.
+    let tailAbsorbed = hre.ethers.BigNumber.from(0);
+    for (const g of activatedGroupAddresses) {
+      if (g === headGroup) continue;
+      tailAbsorbed = tailAbsorbed.add(
+        await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(g, depositor.address)
+      );
+    }
+    expect(tailAbsorbed.gt(0)).to.equal(
+      true,
+      "tail groups must have absorbed the spill over HEAD's realisable"
+    );
+  });
+
+  it("REGRESSION P1 #2: scheduleWithdrawals must accept balance-backed toVote even when Election cap is full", async () => {
+    // Codex P1 #2: Account.withdraw's immediate path serves
+    // min(balance, toVote) via getGoldToken().transfer - it does NOT
+    // call Election.vote and so does not need headroom. A previous
+    // over-restrictive realisable that gated toVote on
+    // electionHeadroom blocked legitimate withdrawals where the
+    // immediate path could have served them right away.
+    //
+    // Setup: deposit via specific strategy, saturate cap BEFORE
+    // activate-bot runs. balance still backs the un-activated toVote
+    // because the bot's activateAndVote silently reverts on cap-full.
+    // Withdraw must SUCCEED via the immediate path (no headroom
+    // required) - assert no revert, full amount delivered.
+
+    await managerContract.connect(depositor).changeStrategy(groups[1].address);
+    await managerContract.connect(depositor).deposit({ value: parseUnits("50") });
+
+    await externalVoterSaturatesGroup(groups[1].address);
+    await activateAndVoteTest();
+
+    const balance = await hre.ethers.provider.getBalance(accountContract.address);
+    const toVote = await accountContract.scheduledVotesForGroup(groups[1].address);
+    expect(balance.gte(parseUnits("50"))).to.equal(
+      true,
+      `test setup: balance must back toVote (got balance=${balance})`
+    );
+    expect(toVote.gte(parseUnits("50"))).to.equal(
+      true,
+      `test setup: toVote must be set (got ${toVote})`
+    );
+
+    // Realisable must include balance-backed toVote even with headroom=0.
+    const realisable = await accountContract.getRealisableCeloForGroup(groups[1].address);
+    expect(realisable.gte(parseUnits("50"))).to.equal(
+      true,
+      `realisable must include balance-backed toVote, got ${realisable}`
+    );
+
+    // Manager.withdraw must succeed - Account.withdraw's immediate path
+    // delivers from balance without needing Election headroom.
+    const stCeloBefore = await stakedCelo.balanceOf(depositor.address);
+    await managerContract.connect(depositor).withdraw(stCeloBefore);
+    expect(await stakedCelo.balanceOf(depositor.address)).to.equal(0);
+  });
+
+  it("REGRESSION P2 #1: rescue must reject when liquid toVote+balance covers user's claim", async () => {
+    // Codex P2 #1: per-beneficiary deficit check must count
+    // min(balance, toVote) + revokable. Without this, a griefer could
+    // call rescueScheduledWithdrawal on a group whose immediate path
+    // would have paid the beneficiary, rerouting them to slower-unbond
+    // groups.
+    //
+    // Setup: depositor specific-strategy on g[1] backed by balance
+    // (cap saturated, no active votes). Then asManager.scheduleWithdrawals
+    // pins a small amount that immediate path could serve. random caller
+    // tries rescue. Must revert GroupNotInDeficit.
+
+    await managerContract.connect(depositor).changeStrategy(groups[1].address);
+    await managerContract.connect(depositor).deposit({ value: parseUnits("50") });
+    await externalVoterSaturatesGroup(groups[1].address);
+    await activateAndVoteTest(); // silently skips g[1] - balance still backs toVote
+
+    const balance = await hre.ethers.provider.getBalance(accountContract.address);
+    const toVote = await accountContract.scheduledVotesForGroup(groups[1].address);
+    expect(balance.gte(toVote)).to.equal(true, "balance must cover toVote");
+
+    // secondDepositor builds active votes on another default group to
+    // serve as a viable rescue destination. Without this, a broken
+    // rescue would revert at _addBeneficiaryWithdrawal due to no
+    // capacity on the destination - obscuring whether the deficit
+    // check passed or failed.
+    await managerContract.connect(secondDepositor).deposit({ value: parseUnits("100") });
+    await activateAndVoteTest();
+    let destGroup: string | undefined;
+    for (const g of activatedGroupAddresses) {
+      if (g === groups[1].address) continue;
+      const celoForG = await accountContract.getCeloForGroup(g);
+      if (celoForG.gte(parseUnits("10"))) {
+        destGroup = g;
+        break;
+      }
+    }
+    expect(destGroup).to.not.equal(undefined, "test setup: need viable rescue destination");
+
+    // Pin a small amount that immediate path can deliver.
+    const managerSigner = await asManager();
+    const pinAmount = parseUnits("10");
+    await accountContract
+      .connect(managerSigner)
+      .scheduleWithdrawals(depositor.address, [groups[1].address], [pinAmount]);
+
+    // Permissionless rescue must revert with GroupNotInDeficit - this
+    // beneficiary's claim is covered by immediate path
+    // (min(balance, toVote)) even though revokable(g[1]) ≈ 0.
+    // Destination has capacity, so a broken rescue would succeed past
+    // _addBeneficiaryWithdrawal.
+    await expect(
+      accountContract
+        .connect(randomCaller)
+        .rescueScheduledWithdrawal(
+          depositor.address,
+          groups[1].address,
+          [destGroup as string],
+          [pinAmount]
+        )
+    ).revertedWith("GroupNotInDeficit");
+
+    // Pin still intact.
+    expect(
+      await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(
+        groups[1].address,
+        depositor.address
+      )
+    ).to.equal(pinAmount);
+  });
+
+  it("REGRESSION P2 #2: rescue must reject when revokable covers user's claim even if group has high toRevoke", async () => {
+    // Codex P2 #2: per-beneficiary deficit check must NOT count
+    // toRevoke. A transfer-accounting deficit (toRevoke > revokable
+    // from queued scheduleTransfer) should not let a griefer rescue
+    // individual beneficiaries whose toWithdrawFor is fully revokable.
+    // Account.withdraw(beneficiary, group) does not consume toRevoke
+    // along the way.
+    //
+    // Setup: depositor specific-strategy, gets active votes. Inject
+    // huge toRevoke via asManager.scheduleTransfer (uses up
+    // bookkeeping revokable headroom). Pin a small toWithdrawFor that
+    // active alone covers. random caller tries rescue. Must revert.
+
+    // secondDepositor default-deposits enough to spread allocation across
+    // other DS groups. Then depositor specific strategy on g[1].
+    await managerContract.connect(secondDepositor).deposit({ value: parseUnits("100") });
+    await managerContract.connect(depositor).changeStrategy(groups[1].address);
+    await managerContract.connect(depositor).deposit({ value: parseUnits("50") });
+    await activateAndVoteTest(); // active(g[1]) = 50, others have some active
+
+    const balancePostActivate = await hre.ethers.provider.getBalance(accountContract.address);
+    expect(balancePostActivate.eq(0)).to.equal(
+      true,
+      "test setup: balance must be drained by activate so toRevoke injection works"
+    );
+
+    // Pick a transfer destination with active to feed the transfer. We
+    // queue toRevoke ON g[1] (source) so g[1]'s books look deficit-prone.
+    let destGroup: string | undefined;
+    for (const g of activatedGroupAddresses) {
+      if (g === groups[1].address) continue;
+      const celoForG = await accountContract.getCeloForGroup(g);
+      if (celoForG.gt(0)) {
+        destGroup = g;
+        break;
+      }
+    }
+    expect(destGroup).to.not.equal(undefined, "test setup: need a destination group");
+
+    // ORDER MATTERS. Pin BEFORE injecting toRevoke. scheduleWithdrawals
+    // is gated by realisable so it must run while realisable still
+    // covers the pin. scheduleTransfer has no such gate so toRevoke can
+    // be inflated afterwards.
+
+    // 1. Pin a small toWithdrawFor that the unmodified revokable easily covers.
+    const managerSigner = await asManager();
+    const pinAmount = parseUnits("5");
+    await accountContract
+      .connect(managerSigner)
+      .scheduleWithdrawals(depositor.address, [groups[1].address], [pinAmount]);
+
+    // 2. Inject toRevoke onto g[1] via scheduleTransfer FROM g[1] TO
+    //    destGroup. Query getCeloForGroup(g[1]) for the max transfer
+    //    amount the scheduleTransfer source check allows. The resulting
+    //    toRevoke + pin > revokable triggers the BROKEN group-wide
+    //    deficit check, even though revokable still covers THIS
+    //    beneficiary's individual pinAmount.
+    const celoAvailable = await accountContract.getCeloForGroup(groups[1].address);
+    const bigToRevoke = celoAvailable;
+    await accountContract
+      .connect(managerSigner)
+      .scheduleTransfer([groups[1].address], [bigToRevoke], [destGroup as string], [bigToRevoke]);
+
+    // Permissionless rescue must revert with GroupNotInDeficit -
+    // per-beneficiary capacity (revokable + immediate) >= pin, so this
+    // beneficiary is NOT in deficit even though group-wide
+    // toRevoke + toWithdraw > revokable. Destination is destGroup which
+    // HAS capacity, so a broken rescue would succeed past
+    // _addBeneficiaryWithdrawal - the only way it reverts is the
+    // per-beneficiary deficit check itself.
+    await expect(
+      accountContract
+        .connect(randomCaller)
+        .rescueScheduledWithdrawal(
+          depositor.address,
+          groups[1].address,
+          [destGroup as string],
+          [pinAmount]
+        )
+    ).revertedWith("GroupNotInDeficit");
+
+    expect(
+      await accountContract.scheduledWithdrawalsForGroupAndBeneficiary(
+        groups[1].address,
+        depositor.address
+      )
+    ).to.equal(pinAmount);
+  });
+
+  it("REGRESSION P2 #6: scheduleWithdrawals must reject multi-group call summing more balance demand than Account holds", async () => {
+    // Codex P2 #6: per-group min(toVote, balance) lets multiple groups
+    // each independently claim the full unlocked Account balance. A
+    // multi-group scheduleWithdrawals call where the sum of
+    // immediate-balance demands exceeds the actual balance could pass
+    // validation pre-fix; the bot's Account.withdraw on the second group
+    // would then revert InsufficientRevokableVotes after the first drained
+    // the shared balance.
+    //
+    // Setup: g[1] has toVote=30 backed by balance=30 (cap saturated, bot
+    // couldn't activate). g[5] has toVote=30 unbacked (via scheduleTransfer
+    // from a healthy source). Multi-group call demands 30+30=60 from
+    // balance which is only 30.
+
+    // a. SGS deposit on g[1]. Saturate cap BEFORE activate so balance
+    //    stays put.
+    await managerContract.connect(depositor).changeStrategy(groups[1].address);
+    await managerContract.connect(depositor).deposit({ value: parseUnits("30") });
+    await externalVoterSaturatesGroup(groups[1].address);
+    await activateAndVoteTest(); // silently skips g[1]; balance stays 30
+
+    const balanceAfterFirst = await hre.ethers.provider.getBalance(accountContract.address);
+    expect(balanceAfterFirst).to.equal(
+      parseUnits("30"),
+      "test setup: balance must be 30 (not activated due to cap)"
+    );
+
+    // b. Build a source group with active votes via secondDepositor
+    //    default deposit. Cannot use g[1] (saturated) as source.
+    await managerContract.connect(secondDepositor).deposit({ value: parseUnits("60") });
+    await activateAndVoteTest();
+
+    // Source must have getCeloForGroup >= 30 for scheduleTransfer.
+    let sourceGroup: string | undefined;
+    for (const g of activatedGroupAddresses) {
+      if (g === groups[1].address) continue;
+      const celoForG = await accountContract.getCeloForGroup(g);
+      if (celoForG.gte(parseUnits("30"))) {
+        sourceGroup = g;
+        break;
+      }
+    }
+    expect(sourceGroup).to.not.equal(
+      undefined,
+      "test setup: need a source group with 30+ getCeloForGroup"
+    );
+
+    // c. asManager.scheduleTransfer injects toVote=30 onto g[5] without
+    //    increasing balance. Now g[5].toVote=30 is unbacked.
+    const managerSigner = await asManager();
+    await accountContract
+      .connect(managerSigner)
+      .scheduleTransfer(
+        [sourceGroup as string],
+        [parseUnits("30")],
+        [groups[5].address],
+        [parseUnits("30")]
+      );
+
+    // d. Multi-group scheduleWithdrawals([g[1], g[5]], [30, 30]).
+    //    Per-group view: g[1] realisable=30 (balance-backed toVote),
+    //    g[5] realisable=30 (balance-backed via same global balance).
+    //    Sum demand 60 > actual balance ~ 30 (modulo secondDepositor
+    //    activated portion). Pre-fix: passes both. Post-fix: shared
+    //    balance budget exhausted on iter 1 -> revert.
+    await expect(
+      accountContract
+        .connect(managerSigner)
+        .scheduleWithdrawals(
+          depositor.address,
+          [groups[1].address, groups[5].address],
+          [parseUnits("30"), parseUnits("30")]
+        )
+    ).reverted;
+  });
+
+  it("REGRESSION P2 #9: scheduleWithdrawals must reserve balance for a group even when revokable alone would cover the withdrawal", async () => {
+    // Codex P2 #9: Account.withdraw line ~424 ALWAYS charges
+    // min(balance, toVote, amount) immediately before falling back to
+    // revoke. A previous fix that only charged the shared budget for the
+    // post-revoke remainder underestimated balance consumption: a group
+    // with both enough revokable votes AND positive toVote actually
+    // drains balance first at withdraw time, so a second group relying
+    // on that same balance was left unfulfillable.
+    //
+    // Setup: g[1] specific-strategy with both balance-backed toVote AND
+    // revokable Election votes; g[5] has unbacked toVote (via
+    // scheduleTransfer). Multi-group call sized so revokable on g[1]
+    // could cover g[1]'s withdrawal entirely, yet Account.withdraw will
+    // still charge balance and starve g[5].
+
+    // a. SGS deposit on g[1] WITH activate (gets revokable=30).
+    await managerContract.connect(depositor).changeStrategy(groups[1].address);
+    await managerContract.connect(depositor).deposit({ value: parseUnits("30") });
+    await activateAndVoteTest(); // active(g[1]) ≈ 30, balance drained
+
+    // b. secondDepositor default deposit to build a source group with
+    //    active votes for the scheduleTransfer below.
+    await managerContract.connect(secondDepositor).deposit({ value: parseUnits("60") });
+    await activateAndVoteTest();
+
+    let sourceGroup: string | undefined;
+    for (const g of activatedGroupAddresses) {
+      if (g === groups[1].address) continue;
+      const celoForG = await accountContract.getCeloForGroup(g);
+      if (celoForG.gte(parseUnits("20"))) {
+        sourceGroup = g;
+        break;
+      }
+    }
+    expect(sourceGroup).to.not.equal(undefined);
+
+    // c. asManager directly injects balance-backed toVote=20 on g[1] via
+    //    scheduleVotes (msg.value=20). Now g[1]: active=30, toVote=20,
+    //    balance contribution=20.
+    const managerSigner = await asManager();
+    await accountContract
+      .connect(managerSigner)
+      .scheduleVotes([groups[1].address], [parseUnits("20")], { value: parseUnits("20") });
+
+    const balanceMid = await hre.ethers.provider.getBalance(accountContract.address);
+    expect(balanceMid).to.equal(
+      parseUnits("20"),
+      "test setup: balance must be 20 (un-activated scheduleVotes injection)"
+    );
+
+    // d. asManager.scheduleTransfer injects toVote=20 onto g[5] without
+    //    increasing balance. g[5].toVote=20 needs the shared balance to
+    //    be paid via immediate path.
+    await accountContract
+      .connect(managerSigner)
+      .scheduleTransfer(
+        [sourceGroup as string],
+        [parseUnits("20")],
+        [groups[5].address],
+        [parseUnits("20")]
+      );
+
+    // d. Multi-group call: [g[1], g[5]], [25, 20]. g[1]'s 25 fits in
+    //    revokable=30 BUT g[1] has toVote=20 + balance=20 so
+    //    Account.withdraw will charge min(20, 20, 25) = 20 from balance
+    //    first. After g[1]: balance=0. g[5] then can't deliver 20 via
+    //    immediate (balance=0) and has revokable=0 -> stuck pin.
+    // Pre-this-fix: per-group passes (g[1] revokable covers 25, g[5]
+    // balance-backed toVote covers 20). Post-fix: shared budget tracks
+    // that g[1] consumed 20 of balance, leaving 0 for g[5] -> revert.
+    await expect(
+      accountContract
+        .connect(managerSigner)
+        .scheduleWithdrawals(
+          depositor.address,
+          [groups[1].address, groups[5].address],
+          [parseUnits("25"), parseUnits("20")]
+        )
+    ).reverted;
+  });
+
+  // Silence unused-import lint on contracts referenced only for typing.
+  it("smoke - contracts deployed", () => {
+    expect(specificGroupStrategyContract.address).to.not.equal("");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the production bug from [forum.celo.org/t/.../13333](https://forum.celo.org/t/i-encountered-a-bug-while-unstake-stcelo-and-request-assistance/13333) where user `0x85ca0Dff027102ea3FBF1c077524eab21D1F7927` unstaked 146,388 stCELO but only 10,000 CELO became claimable - 152,360 CELO is pinned to validator group `0x81AE1C73A326325216E25ff1af9EA3871195036E` with no recovery path.

### Root cause

`Account.scheduleWithdrawals` validated the per-group withdrawal against `getCeloForGroup`, which counts `scheduledVotes.toVote`. When the Election `numVotesReceivable` cap is fully consumed, that `toVote` can never be activated by the bot, so it inflates the apparent group capacity. Withdrawals pass scheduling but later revert `InsufficientRevokableVotes` inside `Account.withdraw`, with no recourse for the user.

### Fix

- **New `Account.getRealisableCeloForGroup`** = `max(0, [max(0, revokable - toRevoke) + min(Account.balance, toVote)] - toWithdraw)`, where `revokable` is the group's pending+active Election votes. Counts only CELO that `Account.withdraw` can physically deliver right now: revokable Election votes, plus the slice of `toVote` actually backed by `Account.balance` (the immediate-withdrawal path transfers it directly without calling `Election.vote`). Existing `toWithdraw` is subtracted once from the combined capacity (withdraw is immediate-first, so a pending withdrawal costs one unit of total capacity, not one per bucket). Stale `toVote` the Election cap permanently blocks is excluded - it has no balance backing.
- **`Account.scheduleWithdrawals`** now books each per-group entry through the shared `_addBeneficiaryWithdrawal` helper, which validates against realisable capacity and threads a `balanceBudget` across groups. `Account.balance` is global and shared across all groups' `toVote`, so per-group validation alone let a multi-group call double-count the same unlocked CELO; the threaded budget models `Account.withdraw`'s immediate-first consumption exactly. Any pin that schedules is physically fulfillable.
- **`DefaultStrategy.generateWithdrawalVoteDistribution`** and **`SpecificGroupStrategy.generateWithdrawalVoteDistribution`** (overflow branch) cap each group by the realisable view for real withdrawals, so distribution spreads across healthy groups instead of pinning to an over-allocated HEAD. The DS loop skips zero-realisable groups (without consuming an output slot) and skips any group already chosen this call, so it never emits the same group twice (a duplicate would revert downstream `scheduleWithdrawals`). The transfer path (`isTransfer=true`, accounting-only) keeps the stCelo cap.
- **New `Account.rescueScheduledWithdrawal(beneficiary, fromGroup, toGroups, amounts)`** - **permissionless** recovery for an already-stuck pin, callable by anyone IFF `fromGroup` is provably in deficit for this beneficiary: `min(toVote, balance) + revokable < toWithdrawFor[beneficiary]` (`_requireGroupInDeficit`, per-beneficiary not per-group). Bookkeeping only (no CELO moves); net change to `totalScheduledWithdrawals` is zero. Source slot is cleared FIRST so a malformed `toGroups` containing `fromGroup` cannot destroy the beneficiary's claim. Beneficiary identity is preserved end-to-end (CELO can only flow to `beneficiary` via `Account.withdraw`), so funds cannot be stolen or destroyed.

### Upgrade safety

Storage layout preserved across `Account`, `DefaultStrategy`, `SpecificGroupStrategy` (append-only logic + new external/private functions, no new state slots). `DefaultStrategy.generateWithdrawalVoteDistribution` gains a `bool isTransfer` parameter; callers in `Manager` and `SpecificGroupStrategy` are updated. Once deployed, **anyone** can unstick the forum user by calling `rescueScheduledWithdrawal` - no multisig governance vote required.

This PR targets **`releases/4`** (the deployed release line) so it can be released directly. Versions are bumped to exactly what the contract-compatibility check requires against `releases/4`: `Account` 1.2.1.0 → **1.2.2.0** (minor: added `getRealisableCeloForGroup` + `rescueScheduledWithdrawal`), `DefaultStrategy` 1.2.0.0 → **1.3.0.0** (major: `generateWithdrawalVoteDistribution` gained the `isTransfer` arg), `SpecificGroupStrategy` 1.1.1.0 → **1.1.1.1** and `Manager` 1.3.1.0 → **1.3.1.1** (patch). Storage layouts unchanged; no new state slots.

## Test plan

- [x] `test-ts/account-realisable.test.ts` - unit tests for `getRealisableCeloForGroup`, `scheduleWithdrawals` prevention, and `rescueScheduledWithdrawal` (incl. deficit gating and the `fromGroup`-in-`toGroups` edge case).
- [x] `test-ts/end-to-end-stuck-withdrawal.test.ts` - e2e regression with real contracts (no mocks): exact root-cause-shape reproduction (unbacked `toVote` -> `scheduleWithdrawals` reverts `WithdrawalAmountTooHigh`), both distribution paths (`DefaultStrategy` realisable cap + `SpecificGroupStrategy` `GroupNotBalanced`), in-flight-transfer unbacked `toVote`, zero-realisable HEAD skip, no-duplicate-group, rescue gating (reject when liquid `toVote`+balance or revokable covers the claim), and shared balance-budget across multi-group calls.
- [x] Duplicate-group regression (HEAD with realisable far below its stCelo - the skip-already-chosen fix) covered by `end-to-end-stuck-withdrawal.test.ts` "REGRESSION P2 #4". `account-realisable.test.ts` also covers the `toWithdraw`-subtracted-once boundary (`C - W`).
- [x] Full suite: **951 passing** (on the `releases/4` base). `yarn lint:ci` clean. Contract-compatibility check passes against `releases/4`.
- [x] `scripts/verify-stuck-withdrawal-mainnet-fork.sh` - anvil fork of **real Celo mainnet state** (24 assertions, all passing). (A) RECOVERY: fork the historical withdrawal block, replay the user's exact `Manager.withdraw` with the deployed code to recreate the stuck pin (the live pin self-resolved post-incident), then a permissionless `rescueScheduledWithdrawal` from a random EOA moves it off the bad group and a real `Account.withdraw` succeeds. (B1) BUG ENTRY at the user's withdrawal block 67413681: deployed code burns 146,388 stCELO and pins 152,349 CELO to the bad group whose Election-revokable is only 100,853 CELO - permanently unfulfillable, exactly how the user got stuck. (B2) PREVENTION at the same block with all four patched impls: the same `Manager.withdraw` caps each pin at realisable capacity (no unfulfillable pin), and a real `Account.withdraw` succeeds. Requires foundry + a Celo RPC; not part of CI.
- [x] Realisable math: `toWithdraw` subtracted once (not twice) from combined capacity - addresses review feedback; full suite + fork re-verified.
- [ ] Multisig deploys new impl and upgrades the three proxies.
- [ ] Anyone calls `Account.rescueScheduledWithdrawal(0x85ca0Dff..., 0x81AE..., [healthy groups], [amounts])` on mainnet.
- [ ] Bot processes the rescheduled withdrawal across healthy groups; user calls `Manager.claim` after the 3-day unbond.

## Known follow-up (not yet addressed)

- MEDIUM: `DefaultStrategy.generateWithdrawalVoteDistribution` can revert `NotAbleToDistributeVotes` via slot-budget exhaustion (`maxGroupsToWithdrawFrom`) when realisable is fragmented across more groups than the slot limit, even though the funds are physically withdrawable. The realisable cap shrinks per-slot contribution, making this more reachable when realisable is tight.
